### PR TITLE
Add the option to compute the full joint wrench.

### DIFF
--- a/src/main/java/us/ihmc/mecano/algorithms/CenterOfMassJacobian.java
+++ b/src/main/java/us/ihmc/mecano/algorithms/CenterOfMassJacobian.java
@@ -51,13 +51,9 @@ public class CenterOfMassJacobian implements ReferenceFrameHolder
     * expressed in the center of mass frame.
     */
    private final ReferenceFrame rootFrame;
-   /**
-    * Defines the multi-body system to use with this calculator.
-    */
+   /** Defines the multi-body system to use with this calculator. */
    private final MultiBodySystemReadOnly input;
-   /**
-    * The root of the internal recursive algorithm.
-    */
+   /** The root of the internal recursive algorithm. */
    private final RecursionStep initialRecursionStep;
    /**
     * Only the first pass of this algorithm has to be recursive, the two other passes can be iterative
@@ -65,36 +61,22 @@ public class CenterOfMassJacobian implements ReferenceFrameHolder
     */
    private final RecursionStep[] recursionSteps;
 
-   /**
-    * The center of mass Jacobian.
-    */
+   /** The center of mass Jacobian. */
    private final DMatrixRMaj jacobianMatrix;
-   /**
-    * Matrix containing the velocities of the joints to consider.
-    */
+   /** Matrix containing the velocities of the joints to consider. */
    private final DMatrixRMaj jointVelocityMatrix;
-   /**
-    * Intermediate variable for garbage free operations.
-    */
+   /** Intermediate variable for garbage free operations. */
    private final DMatrixRMaj centerOfMassVelocityMatrix = new DMatrixRMaj(3, 1);
 
-   /**
-    * Intermediate variable to store one column of the Jacobian matrix.
-    */
+   /** Intermediate variable to store one column of the Jacobian matrix. */
    private final FixedFrameVector3DBasics jacobianColumn;
-   /**
-    * Intermediate variable to store the unit-twist of the parent joint.
-    */
+   /** Intermediate variable to store the unit-twist of the parent joint. */
    private final Twist jointUnitTwist = new Twist();
 
-   /**
-    * The center of mass velocity.
-    */
+   /** The center of mass velocity. */
    private final FixedFrameVector3DBasics centerOfMassVelocity = MecanoFactories.newFixedFrameVector3DBasics(this);
 
-   /**
-    * Whether the Jacobian has been updated since the last call to {@link #reset()}.
-    */
+   /** Whether the Jacobian has been updated since the last call to {@link #reset()}. */
    private boolean isJacobianUpToDate = false;
    /**
     * Whether the center of mass velocity has been updated since the last call to {@link #reset()}.

--- a/src/main/java/us/ihmc/mecano/algorithms/CentroidalMomentumCalculator.java
+++ b/src/main/java/us/ihmc/mecano/algorithms/CentroidalMomentumCalculator.java
@@ -41,61 +41,35 @@ import java.util.List;
  */
 public class CentroidalMomentumCalculator implements ReferenceFrameHolder
 {
-   /**
-    * Defines the multi-body system to use with this calculator.
-    */
+   /** Defines the multi-body system to use with this calculator. */
    private final MultiBodySystemReadOnly input;
-   /**
-    * The center of mass centroidal momentum matrix.
-    */
+   /** The center of mass centroidal momentum matrix. */
    private final ReferenceFrame matrixFrame;
 
-   /**
-    * Array for each iteration of this algorithm.
-    */
+   /** Array for each iteration of this algorithm. */
    private final IterativeStep[] iterativeSteps;
 
-   /**
-    * Intermediate variable to store the unit-twist of the parent joint.
-    */
+   /** Intermediate variable to store the unit-twist of the parent joint. */
    private final Twist jointUnitTwist;
-   /**
-    * Intermediate variable for garbage free operations.
-    */
+   /** Intermediate variable for garbage free operations. */
    private final Twist intermediateUnitTwist;
-   /**
-    * Intermediate variable to store one column of the centroidal momentum matrix.
-    */
+   /** Intermediate variable to store one column of the centroidal momentum matrix. */
    private final Momentum unitMomentum;
-   /**
-    * Intermediate variable for garbage free operations.
-    */
+   /** Intermediate variable for garbage free operations. */
    private final Momentum intermediateMomentum;
-   /**
-    * The total momentum of the system.
-    */
+   /** The total momentum of the system. */
    private final FixedFrameMomentumBasics momentum;
-   /**
-    * The center of mass velocity.
-    */
+   /** The center of mass velocity. */
    private final FixedFrameVector3DBasics centerOfMassVelocity;
 
-   /**
-    * The centroidal momentum matrix.
-    */
+   /** The centroidal momentum matrix. */
    private final DMatrixRMaj centroidalMomentumMatrix;
-   /**
-    * Matrix containing the velocities of the joints to consider.
-    */
+   /** Matrix containing the velocities of the joints to consider. */
    private final DMatrixRMaj jointVelocityMatrix;
-   /**
-    * The total momentum of the system.
-    */
+   /** The total momentum of the system. */
    private final DMatrixRMaj momentumMatrix = new DMatrixRMaj(6, 1);
 
-   /**
-    * The total system mass.
-    */
+   /** The total system mass. */
    private double totalMass = 0.0;
 
    /**
@@ -106,13 +80,9 @@ public class CentroidalMomentumCalculator implements ReferenceFrameHolder
     * Whether the joint velocity matrix has been updated since the last call to {@link #reset()}.
     */
    private boolean isJointVelocityMatrixUpToDate = false;
-   /**
-    * Whether the momentum has been updated since the last call to {@link #reset()}.
-    */
+   /** Whether the momentum has been updated since the last call to {@link #reset()}. */
    private boolean isMomentumUpToDate = false;
-   /**
-    * Whether the total mass has been updated since the last call to {@link #reset()}.
-    */
+   /** Whether the total mass has been updated since the last call to {@link #reset()}. */
    private boolean isTotalMassUpToDate = false;
    /**
     * Whether the center of mass velocity has been updated since the last call to {@link #reset()}.
@@ -524,7 +494,7 @@ public class CentroidalMomentumCalculator implements ReferenceFrameHolder
        * <pre>
        * h = (&sum;<sub>i=0:n</sub> I<sub>i</sub>) * T &equiv; &sum;<sub>i=0:n</sub> (I<sub>i</sub> * T)
        * </pre>
-       * <p>
+       *
        * where <tt>h</tt> is the resulting unit-momentum, <tt>I<sub>i</sub></tt> is the spatial inertia of
        * the i<sup>th</sup> body, and <tt>T</tt> is the unit-twist.
        *

--- a/src/main/java/us/ihmc/mecano/algorithms/CentroidalMomentumRateCalculator.java
+++ b/src/main/java/us/ihmc/mecano/algorithms/CentroidalMomentumRateCalculator.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
  * -- h = A * qDDot + | -- A | * qDot = A * qDDot + b
  * dt                 \ dt   /
  * </pre>
- * <p>
+ *
  * where <tt>h</tt> is the system's momentum, <tt>qDot</tt> and <tt>qDDot</tt> are the joint
  * velocity and acceleration vectors, <tt>A</tt> is the centroidal momentum matrix, and <tt>b</tt>
  * represents the convective term that this calculator also compute and that can be obtained via
@@ -51,17 +51,11 @@ import java.util.stream.Collectors;
  */
 public class CentroidalMomentumRateCalculator implements ReferenceFrameHolder
 {
-   /**
-    * Defines the multi-body system to use with this calculator.
-    */
+   /** Defines the multi-body system to use with this calculator. */
    private final MultiBodySystemReadOnly input;
-   /**
-    * The center of mass centroidal momentum matrix.
-    */
+   /** The center of mass centroidal momentum matrix. */
    private final ReferenceFrame matrixFrame;
-   /**
-    * The root of the internal recursive algorithm.
-    */
+   /** The root of the internal recursive algorithm. */
    private final RecursionStep initialRecursionStep;
    /**
     * Only the first pass of this algorithm has to be recursive, the rest can be iterative which can
@@ -69,68 +63,42 @@ public class CentroidalMomentumRateCalculator implements ReferenceFrameHolder
     */
    private final RecursionStep[] recursionSteps;
    private final Map<RigidBodyReadOnly, RecursionStep> rigidBodyToRecursionStepMap;
-   /**
-    * Intermediate variable to store the unit-twist of the parent joint.
-    */
+   /** Intermediate variable to store the unit-twist of the parent joint. */
    private final Twist jointUnitTwist;
-   /**
-    * Intermediate variable for garbage free operations.
-    */
+   /** Intermediate variable for garbage free operations. */
    private final Twist intermediateTwist;
-   /**
-    * Intermediate variable to store one column of the centroidal momentum matrix.
-    */
+   /** Intermediate variable to store one column of the centroidal momentum matrix. */
    private final Momentum unitMomentum;
-   /**
-    * Intermediate variable for garbage free operations.
-    */
+   /** Intermediate variable for garbage free operations. */
    private final Momentum intermediateMomentum;
 
-   /**
-    * The centroidal momentum matrix.
-    */
+   /** The centroidal momentum matrix. */
    private final DMatrixRMaj centroidalMomentumMatrix;
    /**
     * The convective term resulting from the Coriolis and centrifugal forces acting on the system.
     */
    private final SpatialForce biasSpatialForce;
-   /**
-    * The total momentum of the system.
-    */
+   /** The total momentum of the system. */
    private final FixedFrameMomentumBasics momentum;
-   /**
-    * The total rate of change of momentum of the system.
-    */
+   /** The total rate of change of momentum of the system. */
    private final FixedFrameSpatialForceBasics momentumRate;
-   /**
-    * The center of mass velocity.
-    */
+   /** The center of mass velocity. */
    private final FixedFrameVector3DBasics centerOfMassVelocity;
-   /**
-    * The center of mass acceleration.
-    */
+   /** The center of mass acceleration. */
    private final FixedFrameVector3DBasics centerOfMassAcceleration;
 
    /**
     * The convective term resulting from the Coriolis and centrifugal forces acting on the system.
     */
    private final DMatrixRMaj biasSpatialForceMatrix = new DMatrixRMaj(6, 1);
-   /**
-    * Matrix containing the velocities of the joints to consider.
-    */
+   /** Matrix containing the velocities of the joints to consider. */
    private final DMatrixRMaj jointVelocityMatrix;
-   /**
-    * Matrix containing the accelerations of the joints to consider.
-    */
+   /** Matrix containing the accelerations of the joints to consider. */
    private final DMatrixRMaj jointAccelerationMatrix;
-   /**
-    * The total momentum of the system.
-    */
+   /** The total momentum of the system. */
    private final DMatrixRMaj momentumMatrix = new DMatrixRMaj(6, 1);
 
-   /**
-    * The total system mass.
-    */
+   /** The total system mass. */
    private double totalMass = 0.0;
 
    /**
@@ -145,17 +113,13 @@ public class CentroidalMomentumRateCalculator implements ReferenceFrameHolder
     * Whether the joint acceleration matrix has been updated since the last call to {@link #reset()}.
     */
    private boolean isJointAccelerationMatrixUpToDate = false;
-   /**
-    * Whether the momentum has been updated since the last call to {@link #reset()}.
-    */
+   /** Whether the momentum has been updated since the last call to {@link #reset()}. */
    private boolean isMomentumUpToDate = false;
    /**
     * Whether the rate of change of momentum has been updated since the last call to {@link #reset()}.
     */
    private boolean isMomentumRateUpToDate = false;
-   /**
-    * Whether the total mass has been updated since the last call to {@link #reset()}.
-    */
+   /** Whether the total mass has been updated since the last call to {@link #reset()}. */
    private boolean isTotalMassUpToDate = false;
    /**
     * Whether the center of mass velocity has been updated since the last call to {@link #reset()}.
@@ -591,8 +555,8 @@ public class CentroidalMomentumRateCalculator implements ReferenceFrameHolder
    /**
     * Computes the convective term while considering only a subset of the multi-body system.
     *
-    * @param jointSelection         the only joints that are considered.
-    * @param biasSpatialForceToPack the matrix used to store the result. Modified.
+    * @param jointSelection               the only joints that are considered.
+    * @param biasSpatialForceMatrixToPack the matrix used to store the result. Modified.
     * @return {@code true} if the convective term was successfully computed, {@code false} if not all
     *       the joints could be found and the result is inaccurate.
     */
@@ -636,9 +600,7 @@ public class CentroidalMomentumRateCalculator implements ReferenceFrameHolder
     */
    private class RecursionStep
    {
-      /**
-       * The rigid-body for which this recursion is.
-       */
+      /** The rigid-body for which this recursion is. */
       private final RigidBodyReadOnly rigidBody;
       /**
        * Body inertia: usually equal to {@code rigidBody.getInertial()}. However, if at least one child of
@@ -655,9 +617,7 @@ public class CentroidalMomentumRateCalculator implements ReferenceFrameHolder
        * joint.
        */
       private final DMatrixRMaj centroidalMomentumMatrixBlock;
-      /**
-       * The Coriolis and centrifugal accelerations for this rigid-body.
-       */
+      /** The Coriolis and centrifugal accelerations for this rigid-body. */
       private final SpatialAcceleration coriolisBodyAcceleration;
       /**
        * Intermediate variable to prevent repetitive calculation of a transform between this rigid-body's
@@ -785,7 +745,7 @@ public class CentroidalMomentumRateCalculator implements ReferenceFrameHolder
        * <pre>
        * h = (&sum;<sub>i=0:n</sub> I<sub>i</sub>) * T &equiv; &sum;<sub>i=0:n</sub> (I<sub>i</sub> * T)
        * </pre>
-       * <p>
+       *
        * where <tt>h</tt> is the resulting unit-momentum, <tt>I<sub>i</sub></tt> is the spatial inertia of
        * the i<sup>th</sup> body, and <tt>T</tt> is the unit-twist.
        *

--- a/src/main/java/us/ihmc/mecano/algorithms/CentroidalMomentumRateCalculator.java
+++ b/src/main/java/us/ihmc/mecano/algorithms/CentroidalMomentumRateCalculator.java
@@ -1,17 +1,8 @@
 package us.ihmc.mecano.algorithms;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
 import org.ejml.data.DMatrix1Row;
 import org.ejml.data.DMatrixRMaj;
 import org.ejml.dense.row.CommonOps_DDRM;
-
 import us.ihmc.euclid.referenceFrame.FrameVector3D;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.referenceFrame.interfaces.FixedFrameVector3DBasics;
@@ -24,23 +15,15 @@ import us.ihmc.mecano.multiBodySystem.interfaces.JointMatrixIndexProvider;
 import us.ihmc.mecano.multiBodySystem.interfaces.JointReadOnly;
 import us.ihmc.mecano.multiBodySystem.interfaces.MultiBodySystemReadOnly;
 import us.ihmc.mecano.multiBodySystem.interfaces.RigidBodyReadOnly;
-import us.ihmc.mecano.spatial.Momentum;
-import us.ihmc.mecano.spatial.SpatialAcceleration;
-import us.ihmc.mecano.spatial.SpatialForce;
-import us.ihmc.mecano.spatial.SpatialInertia;
-import us.ihmc.mecano.spatial.Twist;
-import us.ihmc.mecano.spatial.Wrench;
-import us.ihmc.mecano.spatial.interfaces.FixedFrameMomentumBasics;
-import us.ihmc.mecano.spatial.interfaces.FixedFrameSpatialForceBasics;
-import us.ihmc.mecano.spatial.interfaces.MomentumBasics;
-import us.ihmc.mecano.spatial.interfaces.MomentumReadOnly;
-import us.ihmc.mecano.spatial.interfaces.SpatialForceBasics;
-import us.ihmc.mecano.spatial.interfaces.SpatialForceReadOnly;
-import us.ihmc.mecano.spatial.interfaces.SpatialInertiaReadOnly;
-import us.ihmc.mecano.spatial.interfaces.TwistReadOnly;
+import us.ihmc.mecano.spatial.*;
+import us.ihmc.mecano.spatial.interfaces.*;
 import us.ihmc.mecano.tools.JointStateType;
 import us.ihmc.mecano.tools.MecanoTools;
 import us.ihmc.mecano.tools.MultiBodySystemTools;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Computes the centroidal momentum matrix that maps from joint velocity space to the system linear
@@ -53,7 +36,7 @@ import us.ihmc.mecano.tools.MultiBodySystemTools;
  * -- h = A * qDDot + | -- A | * qDot = A * qDDot + b
  * dt                 \ dt   /
  * </pre>
- *
+ * <p>
  * where <tt>h</tt> is the system's momentum, <tt>qDot</tt> and <tt>qDDot</tt> are the joint
  * velocity and acceleration vectors, <tt>A</tt> is the centroidal momentum matrix, and <tt>b</tt>
  * represents the convective term that this calculator also compute and that can be obtained via
@@ -68,11 +51,17 @@ import us.ihmc.mecano.tools.MultiBodySystemTools;
  */
 public class CentroidalMomentumRateCalculator implements ReferenceFrameHolder
 {
-   /** Defines the multi-body system to use with this calculator. */
+   /**
+    * Defines the multi-body system to use with this calculator.
+    */
    private final MultiBodySystemReadOnly input;
-   /** The center of mass centroidal momentum matrix. */
+   /**
+    * The center of mass centroidal momentum matrix.
+    */
    private final ReferenceFrame matrixFrame;
-   /** The root of the internal recursive algorithm. */
+   /**
+    * The root of the internal recursive algorithm.
+    */
    private final RecursionStep initialRecursionStep;
    /**
     * Only the first pass of this algorithm has to be recursive, the rest can be iterative which can
@@ -80,42 +69,68 @@ public class CentroidalMomentumRateCalculator implements ReferenceFrameHolder
     */
    private final RecursionStep[] recursionSteps;
    private final Map<RigidBodyReadOnly, RecursionStep> rigidBodyToRecursionStepMap;
-   /** Intermediate variable to store the unit-twist of the parent joint. */
+   /**
+    * Intermediate variable to store the unit-twist of the parent joint.
+    */
    private final Twist jointUnitTwist;
-   /** Intermediate variable for garbage free operations. */
+   /**
+    * Intermediate variable for garbage free operations.
+    */
    private final Twist intermediateTwist;
-   /** Intermediate variable to store one column of the centroidal momentum matrix. */
+   /**
+    * Intermediate variable to store one column of the centroidal momentum matrix.
+    */
    private final Momentum unitMomentum;
-   /** Intermediate variable for garbage free operations. */
+   /**
+    * Intermediate variable for garbage free operations.
+    */
    private final Momentum intermediateMomentum;
 
-   /** The centroidal momentum matrix. */
+   /**
+    * The centroidal momentum matrix.
+    */
    private final DMatrixRMaj centroidalMomentumMatrix;
    /**
     * The convective term resulting from the Coriolis and centrifugal forces acting on the system.
     */
    private final SpatialForce biasSpatialForce;
-   /** The total momentum of the system. */
+   /**
+    * The total momentum of the system.
+    */
    private final FixedFrameMomentumBasics momentum;
-   /** The total rate of change of momentum of the system. */
+   /**
+    * The total rate of change of momentum of the system.
+    */
    private final FixedFrameSpatialForceBasics momentumRate;
-   /** The center of mass velocity. */
+   /**
+    * The center of mass velocity.
+    */
    private final FixedFrameVector3DBasics centerOfMassVelocity;
-   /** The center of mass acceleration. */
+   /**
+    * The center of mass acceleration.
+    */
    private final FixedFrameVector3DBasics centerOfMassAcceleration;
 
    /**
     * The convective term resulting from the Coriolis and centrifugal forces acting on the system.
     */
    private final DMatrixRMaj biasSpatialForceMatrix = new DMatrixRMaj(6, 1);
-   /** Matrix containing the velocities of the joints to consider. */
+   /**
+    * Matrix containing the velocities of the joints to consider.
+    */
    private final DMatrixRMaj jointVelocityMatrix;
-   /** Matrix containing the accelerations of the joints to consider. */
+   /**
+    * Matrix containing the accelerations of the joints to consider.
+    */
    private final DMatrixRMaj jointAccelerationMatrix;
-   /** The total momentum of the system. */
+   /**
+    * The total momentum of the system.
+    */
    private final DMatrixRMaj momentumMatrix = new DMatrixRMaj(6, 1);
 
-   /** The total system mass. */
+   /**
+    * The total system mass.
+    */
    private double totalMass = 0.0;
 
    /**
@@ -130,13 +145,17 @@ public class CentroidalMomentumRateCalculator implements ReferenceFrameHolder
     * Whether the joint acceleration matrix has been updated since the last call to {@link #reset()}.
     */
    private boolean isJointAccelerationMatrixUpToDate = false;
-   /** Whether the momentum has been updated since the last call to {@link #reset()}. */
+   /**
+    * Whether the momentum has been updated since the last call to {@link #reset()}.
+    */
    private boolean isMomentumUpToDate = false;
    /**
     * Whether the rate of change of momentum has been updated since the last call to {@link #reset()}.
     */
    private boolean isMomentumRateUpToDate = false;
-   /** Whether the total mass has been updated since the last call to {@link #reset()}. */
+   /**
+    * Whether the total mass has been updated since the last call to {@link #reset()}.
+    */
    private boolean isTotalMassUpToDate = false;
    /**
     * Whether the center of mass velocity has been updated since the last call to {@link #reset()}.
@@ -219,22 +238,7 @@ public class CentroidalMomentumRateCalculator implements ReferenceFrameHolder
       List<RecursionStep> recursionSteps = new ArrayList<>();
       recursionSteps.add(parent);
 
-      List<JointReadOnly> childrenJoints = new ArrayList<>(parent.rigidBody.getChildrenJoints());
-
-      if (childrenJoints.size() > 1)
-      { // Reorganize the joints in the children to ensure that loop closures are treated last.
-         List<JointReadOnly> loopClosureAncestors = new ArrayList<>();
-
-         for (int i = 0; i < childrenJoints.size();)
-         {
-            if (MultiBodySystemTools.doesSubtreeContainLoopClosure(childrenJoints.get(i).getSuccessor()))
-               loopClosureAncestors.add(childrenJoints.remove(i));
-            else
-               i++;
-         }
-
-         childrenJoints.addAll(loopClosureAncestors);
-      }
+      List<JointReadOnly> childrenJoints = MultiBodySystemTools.sortLoopClosureInChildrenJoints(parent.rigidBody);
 
       for (JointReadOnly childJoint : childrenJoints)
       {
@@ -544,11 +548,11 @@ public class CentroidalMomentumRateCalculator implements ReferenceFrameHolder
 
    /**
     * Computes the convective term while considering only a subset of the multi-body system.
-    * 
+    *
     * @param jointSelection         the only joints that are considered.
     * @param biasSpatialForceToPack the vector used to store the result. Modified.
     * @return {@code true} if the convective term was successfully computed, {@code false} if not all
-    *         the joints could be found and the result is inaccurate.
+    *       the joints could be found and the result is inaccurate.
     */
    public boolean getBiasSpatialForceMatrix(List<? extends JointReadOnly> jointSelection, SpatialForceBasics biasSpatialForceToPack)
    {
@@ -586,11 +590,11 @@ public class CentroidalMomentumRateCalculator implements ReferenceFrameHolder
 
    /**
     * Computes the convective term while considering only a subset of the multi-body system.
-    * 
+    *
     * @param jointSelection         the only joints that are considered.
     * @param biasSpatialForceToPack the matrix used to store the result. Modified.
     * @return {@code true} if the convective term was successfully computed, {@code false} if not all
-    *         the joints could be found and the result is inaccurate.
+    *       the joints could be found and the result is inaccurate.
     */
    public boolean getBiasSpatialForceMatrix(List<? extends JointReadOnly> jointSelection, DMatrixRMaj biasSpatialForceMatrixToPack)
    {
@@ -632,7 +636,9 @@ public class CentroidalMomentumRateCalculator implements ReferenceFrameHolder
     */
    private class RecursionStep
    {
-      /** The rigid-body for which this recursion is. */
+      /**
+       * The rigid-body for which this recursion is.
+       */
       private final RigidBodyReadOnly rigidBody;
       /**
        * Body inertia: usually equal to {@code rigidBody.getInertial()}. However, if at least one child of
@@ -649,7 +655,9 @@ public class CentroidalMomentumRateCalculator implements ReferenceFrameHolder
        * joint.
        */
       private final DMatrixRMaj centroidalMomentumMatrixBlock;
-      /** The Coriolis and centrifugal accelerations for this rigid-body. */
+      /**
+       * The Coriolis and centrifugal accelerations for this rigid-body.
+       */
       private final SpatialAcceleration coriolisBodyAcceleration;
       /**
        * Intermediate variable to prevent repetitive calculation of a transform between this rigid-body's
@@ -762,7 +770,6 @@ public class CentroidalMomentumRateCalculator implements ReferenceFrameHolder
             int column = jointIndices[dofIndex];
             CommonOps_DDRM.extract(centroidalMomentumMatrixBlock, 0, 6, dofIndex, dofIndex + 1, centroidalMomentumMatrix, 0, column);
          }
-
       }
 
       /**
@@ -778,7 +785,7 @@ public class CentroidalMomentumRateCalculator implements ReferenceFrameHolder
        * <pre>
        * h = (&sum;<sub>i=0:n</sub> I<sub>i</sub>) * T &equiv; &sum;<sub>i=0:n</sub> (I<sub>i</sub> * T)
        * </pre>
-       *
+       * <p>
        * where <tt>h</tt> is the resulting unit-momentum, <tt>I<sub>i</sub></tt> is the spatial inertia of
        * the i<sup>th</sup> body, and <tt>T</tt> is the unit-twist.
        *

--- a/src/main/java/us/ihmc/mecano/algorithms/CompositeRigidBodyMassMatrixCalculator.java
+++ b/src/main/java/us/ihmc/mecano/algorithms/CompositeRigidBodyMassMatrixCalculator.java
@@ -47,7 +47,7 @@ import java.util.List;
  * <pre>
  * &tau; = H(q) qDDot + C(q, qDot) qDot + G(q) + &sum;<sub>i</sub> J<sub>i</sub> W<sub>i, ext</sub>
  * </pre>
- * <p>
+ *
  * where <tt>&tau;</tt>, <tt>q</tt>, <tt>qDot</tt>, and <tt>qDDot</tt> are the joint effort,
  * configuration, velocity, and acceleration vectors, <tt>H</tt> is the joint-space inertia matrix
  * or also called here mass matrix, <tt>C</tt> is the Coriolis and centrifugal matrix, <tt>G</tt>
@@ -70,7 +70,7 @@ import java.util.List;
  * -- = A * qDDot + -- * qDot = A * qDDot + b
  * dt               dt
  * </pre>
- * <p>
+ *
  * where <tt>h</tt> is the system's momentum and <tt>A</tt> is the centroidal momentum matrix, the
  * term introduce <tt>b</tt> represents the convective term.
  * </p>
@@ -85,37 +85,25 @@ import java.util.List;
  */
 public class CompositeRigidBodyMassMatrixCalculator
 {
-   /**
-    * Defines the multi-body system to use with this calculator.
-    */
+   /** Defines the multi-body system to use with this calculator. */
    private final MultiBodySystemReadOnly input;
 
-   /**
-    * The root of the internal recursive algorithm.
-    */
+   /** The root of the internal recursive algorithm. */
    private final CompositeRigidBodyInertia rootCompositeInertia;
    /**
     * Array of all the recursion steps but the root. This allows to efficiently iterate through when
     * computing the centroidal momentum matrix.
     */
    private final CompositeRigidBodyInertia[] compositeInertias;
-   /**
-    * The mass matrix of the system.
-    */
+   /** The mass matrix of the system. */
    private final DMatrixRMaj massMatrix;
    private final DMatrixRMaj coriolisMatrix;
-   /**
-    * Intermediate variable to store the child inertia.
-    */
+   /** Intermediate variable to store the child inertia. */
    private final SpatialInertia childInertia = new SpatialInertia();
-   /**
-    * Intermediate variable to store the child factorized inertia.
-    */
+   /** Intermediate variable to store the child factorized inertia. */
    private final FactorizedBodyInertia childFactorizedInertia = new FactorizedBodyInertia();
 
-   /**
-    * Intermediate variable for garbage free operations.
-    */
+   /** Intermediate variable for garbage free operations. */
    private final Twist intermediateTwist = new Twist();
    /**
     * Intermediate variable to store the wrench resulting from Coriolis and centrifugal accelerations.
@@ -134,9 +122,7 @@ public class CompositeRigidBodyMassMatrixCalculator
     */
    private final DMatrixRMaj centroidalConvectiveTermMatrix = new DMatrixRMaj(6, 1);
 
-   /**
-    * Frame in which the centroidal momentum matrix and its convective term are to be calculated.
-    */
+   /** Frame in which the centroidal momentum matrix and its convective term are to be calculated. */
    private ReferenceFrame centroidalMomentumFrame;
    /**
     * The centroidal momentum matrix represents the map from joint velocity space to momentum space.
@@ -483,13 +469,9 @@ public class CompositeRigidBodyMassMatrixCalculator
        */
       private final int[] jointIndices;
 
-      /**
-       * Spatial inertia representing the subtree starting off this rigid-body.
-       */
+      /** Spatial inertia representing the subtree starting off this rigid-body. */
       private final SpatialInertia compositeInertia;
-      /**
-       * Spatial factorized inertia representing the subtree starting off this rigid-body.
-       */
+      /** Spatial factorized inertia representing the subtree starting off this rigid-body. */
       private final FactorizedBodyInertia compositeFactorizedInertia;
 
       /**
@@ -498,18 +480,12 @@ public class CompositeRigidBodyMassMatrixCalculator
        */
       private final Momentum[] F1, F2, F3;
       private final DMatrixRMaj motionSubspaceDot;
-      /**
-       * This parent joint unit-twists.
-       */
+      /** This parent joint unit-twists. */
       private final Twist[] unitTwists;
-      /**
-       * The time-derivative of this parent joint unit-twists.
-       */
+      /** The time-derivative of this parent joint unit-twists. */
       private final SpatialAcceleration[] unitTwistDots;
 
-      /**
-       * The Coriolis and centrifugal accelerations for this rigid-body.
-       */
+      /** The Coriolis and centrifugal accelerations for this rigid-body. */
       private final SpatialAcceleration coriolisBodyAcceleration;
       /**
        * Transform from {@code this.getFrameAfterJoint()} to {@code parent.getFrameAfterJoint()} used to

--- a/src/main/java/us/ihmc/mecano/algorithms/ForwardDynamicsCalculator.java
+++ b/src/main/java/us/ihmc/mecano/algorithms/ForwardDynamicsCalculator.java
@@ -56,22 +56,14 @@ public class ForwardDynamicsCalculator
       ACCELERATION_SOURCE;
    }
 
-   /**
-    * Defines the multi-body system to use with this calculator.
-    */
+   /** Defines the multi-body system to use with this calculator. */
    private final MultiBodySystemReadOnly input;
 
-   /**
-    * The root of the internal recursive algorithm.
-    */
+   /** The root of the internal recursive algorithm. */
    private final ArticulatedBodyRecursionStep initialRecursionStep;
-   /**
-    * Map to quickly retrieve information for each rigid-body.
-    */
+   /** Map to quickly retrieve information for each rigid-body. */
    private final Map<RigidBodyReadOnly, ArticulatedBodyRecursionStep> rigidBodyToRecursionStepMap = new LinkedHashMap<>();
-   /**
-    * For iterating over each rigid-body quickly.
-    */
+   /** For iterating over each rigid-body quickly. */
    private final ArticulatedBodyRecursionStep[] articulatedBodyRecursionSteps;
 
    private boolean isJointTauOutputDirty = true;
@@ -738,9 +730,7 @@ public class ForwardDynamicsCalculator
       return considerVelocities ? accelerationProvider : zeroVelocityAccelerationProvider;
    }
 
-   /**
-    * Intermediate result used for garbage free operations.
-    */
+   /** Intermediate result used for garbage free operations. */
    private final SpatialForce jointForceFromChild = new SpatialForce();
 
    /**
@@ -798,7 +788,7 @@ public class ForwardDynamicsCalculator
        *  <sup> </sup> = I<sup>A</sup> - U ( S<sup>T</sup> U )<sup>-1</sup> U<sup>T</sup>
        *  <sup> </sup> = I<sup>A</sup> - I<sup>A</sup> S ( S<sup>T</sup> I<sup>A</sup> S )<sup>-1</sup> S<sup>T</sup> I<sup>A</sup>
        * </pre>
-       * <p>
+       *
        * where <tt>I<sup>A</sup></tt> is this handle's articulated-body inertia, and <tt>S</tt> is the
        * parent joint motion subspace.
        */
@@ -827,7 +817,7 @@ public class ForwardDynamicsCalculator
        * <pre>
        * U = I<sup>A</sup> S
        * </pre>
-       * <p>
+       *
        * where <tt>I<sup>A</sup></tt> is this handle's articulated-body inertia, and <tt>S</tt> is the
        * parent joint motion subspace.
        */
@@ -839,7 +829,7 @@ public class ForwardDynamicsCalculator
        * D = S<sup>T</sup> U
        *   = S<sup>T</sup> I<sup>A</sup> S
        * </pre>
-       * <p>
+       *
        * where <tt>I<sup>A</sup></tt> is this handle's articulated-body inertia, and <tt>S</tt> is the
        * parent joint motion subspace.
        */
@@ -851,7 +841,7 @@ public class ForwardDynamicsCalculator
        * D<sup>-1</sup> = ( S<sup>T</sup> U )<sup>-1</sup>
        *  <sub>  </sub> = ( S<sup>T</sup> I<sup>A</sup> S )<sup>-1</sup>
        * </pre>
-       * <p>
+       *
        * where <tt>I<sup>A</sup></tt> is this handle's articulated-body inertia, and <tt>S</tt> is the
        * parent joint motion subspace.
        */
@@ -863,7 +853,7 @@ public class ForwardDynamicsCalculator
        * U D<sup>-1</sup> = U ( S<sup>T</sup> U )<sup>-1</sup>
        *    <sub>  </sub> = I<sup>A</sup> S ( S<sup>T</sup> I<sup>A</sup> S )<sup>-1</sup>
        * </pre>
-       * <p>
+       *
        * where <tt>I<sup>A</sup></tt> is this handle's articulated-body inertia, and <tt>S</tt> is the
        * parent joint motion subspace.
        */
@@ -875,7 +865,7 @@ public class ForwardDynamicsCalculator
        * U D<sup>-1</sup> U<sup>T</sup> = U ( S<sup>T</sup> U )<sup>-1</sup> U<sup>T</sup>
        *      <sub>   </sub> = I<sup>A</sup> S ( S<sup>T</sup> I<sup>A</sup> S )<sup>-1</sup> S<sup>T</sup> I<sup>A</sup>
        * </pre>
-       * <p>
+       *
        * where <tt>I<sup>A</sup></tt> is this handle's articulated-body inertia, and <tt>S</tt> is the
        * parent joint motion subspace.
        */
@@ -891,7 +881,7 @@ public class ForwardDynamicsCalculator
        * <pre>
        * u = &tau; - S<sup>T</sup> p<sup>A</sup>
        * </pre>
-       * <p>
+       *
        * where <tt>&tau;</tt> is the N-by-1 vector representing the joint effort, N being the number of
        * DoFs for this joint, <tt>S</tt> is the joint motion subspace, and <tt>p<sup>A</sup></tt> some
        * bias forces exerted on this joint.
@@ -903,7 +893,7 @@ public class ForwardDynamicsCalculator
        * <pre>
        * c = v &times; ( S qDot )
        * </pre>
-       * <p>
+       *
        * where <tt>v</tt> is the twist of this body, <tt>S</tt> the joint motion subspace, and
        * <tt>qDot</tt> the N-by-1 vector for this joint velocity, with N being the number of DoFs for this
        * joint.
@@ -916,7 +906,7 @@ public class ForwardDynamicsCalculator
        * p<sup>a</sup> = p<sup>A</sup> + I<sup>a</sup> c + U D<sup>-1</sup> u
        *  <sup> </sup> = p<sup>A</sup> + I<sup>a</sup> c + I<sup>A</sup> S ( S<sup>T</sup> I<sup>A</sup> S )<sup>-1</sup> ( &tau; - S<sup>T</sup> p<sup>A</sup> )
        * </pre>
-       * <p>
+       *
        * where <tt>p<sup>A</sup></tt> are the bias forces acting on this joint, <tt>I<sup>a</sup></tt> is
        * the apparent articulated-body inertia for the parent, <tt>S</tt> is the joint motion subspace,
        * <tt>I<sup>A</sup></tt> this handle's articulated-body inertia, <tt>&tau;</tt> this joint effort,

--- a/src/main/java/us/ihmc/mecano/algorithms/InverseDynamicsCalculator.java
+++ b/src/main/java/us/ihmc/mecano/algorithms/InverseDynamicsCalculator.java
@@ -1,16 +1,8 @@
 package us.ihmc.mecano.algorithms;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-
 import org.ejml.data.DMatrix;
 import org.ejml.data.DMatrixRMaj;
 import org.ejml.dense.row.CommonOps_DDRM;
-
 import us.ihmc.euclid.referenceFrame.exceptions.ReferenceFrameMismatchException;
 import us.ihmc.euclid.referenceFrame.interfaces.FrameTuple3DReadOnly;
 import us.ihmc.euclid.tools.EuclidCoreIOTools;
@@ -18,14 +10,13 @@ import us.ihmc.euclid.tuple3D.interfaces.Tuple3DReadOnly;
 import us.ihmc.mecano.algorithms.interfaces.RigidBodyAccelerationProvider;
 import us.ihmc.mecano.frames.MovingReferenceFrame;
 import us.ihmc.mecano.multiBodySystem.interfaces.*;
-import us.ihmc.mecano.spatial.SpatialAcceleration;
-import us.ihmc.mecano.spatial.SpatialForce;
-import us.ihmc.mecano.spatial.SpatialInertia;
-import us.ihmc.mecano.spatial.Twist;
-import us.ihmc.mecano.spatial.Wrench;
+import us.ihmc.mecano.spatial.*;
 import us.ihmc.mecano.spatial.interfaces.*;
 import us.ihmc.mecano.tools.JointStateType;
 import us.ihmc.mecano.tools.MultiBodySystemTools;
+
+import java.util.*;
+import java.util.function.Function;
 
 /**
  * Computes joint efforts based on joint accelerations.
@@ -49,23 +40,39 @@ public class InverseDynamicsCalculator
    private static final boolean DEFAULT_CONSIDER_ACCELERATIONS = true;
    private static final boolean DEFAULT_CONSIDER_CORIOLIS = true;
 
-   /** Defines the multi-body system to use with this calculator. */
+   /**
+    * Defines the multi-body system to use with this calculator.
+    */
    private final MultiBodySystemReadOnly input;
-   /** The root of the internal recursive algorithm. */
+   /**
+    * The root of the internal recursive algorithm.
+    */
    final RecursionStep initialRecursionStep;
-   /** Map to quickly retrieve information for each rigid-body. */
+   /**
+    * Map to quickly retrieve information for each rigid-body.
+    */
    final Map<RigidBodyReadOnly, RecursionStep> rigidBodyToRecursionStepMap = new LinkedHashMap<>();
-   /** Map to quickly retrieve information for each joint. */
+   /**
+    * Map to quickly retrieve information for each joint.
+    */
    private final Map<JointReadOnly, RecursionStepBasics> jointToRecursionStepMap = new LinkedHashMap<>();
 
-   /** The input of this algorithm: the acceleration matrix for all the joints to consider. */
+   /**
+    * The input of this algorithm: the acceleration matrix for all the joints to consider.
+    */
    private final DMatrixRMaj allJointAccelerationMatrix;
-   /** The output of this algorithm: the effort matrix for all the joints to consider. */
+   /**
+    * The output of this algorithm: the effort matrix for all the joints to consider.
+    */
    private final DMatrixRMaj allJointTauMatrix;
 
-   /** Whether the effort resulting from the joint accelerations should be considered. */
+   /**
+    * Whether the effort resulting from the joint accelerations should be considered.
+    */
    private boolean considerJointAccelerations = DEFAULT_CONSIDER_ACCELERATIONS;
-   /** Whether the effort resulting from the Coriolis and centrifugal forces should be considered. */
+   /**
+    * Whether the effort resulting from the Coriolis and centrifugal forces should be considered.
+    */
    private boolean considerCoriolisAndCentrifugalForces = DEFAULT_CONSIDER_CORIOLIS;
    /**
     * Extension of this algorithm into an acceleration provider that be used instead of a
@@ -89,11 +96,11 @@ public class InverseDynamicsCalculator
     *                                             accelerations should be considered.
     * @deprecated Use the following code snippet instead:
     *
-    *             <pre>
-    *             InverseDynamicsCalculator calculator = new InverseDynamicsCalculator(rootBody);
-    *             calculator.setConsiderCoriolisAndCentrifugalForces(considerCoriolisAndCentrifugalForces);
-    *             calculator.setConsiderJointAccelerations(considerJointAccelerations);
-    *             </pre>
+    *       <pre>
+    *                                                                                                                               InverseDynamicsCalculator calculator = new InverseDynamicsCalculator(rootBody);
+    *                                                                                                                               calculator.setConsiderCoriolisAndCentrifugalForces(considerCoriolisAndCentrifugalForces);
+    *                                                                                                                               calculator.setConsiderJointAccelerations(considerJointAccelerations);
+    *                                                                                                                               </pre>
     */
    @Deprecated
    public InverseDynamicsCalculator(RigidBodyReadOnly rootBody, boolean considerCoriolisAndCentrifugalForces, boolean considerJointAccelerations)
@@ -119,11 +126,11 @@ public class InverseDynamicsCalculator
     *                                             accelerations should be considered.
     * @deprecated Use the following code snippet instead:
     *
-    *             <pre>
-    *             InverseDynamicsCalculator calculator = new InverseDynamicsCalculator(input);
-    *             calculator.setConsiderCoriolisAndCentrifugalForces(considerCoriolisAndCentrifugalForces);
-    *             calculator.setConsiderJointAccelerations(considerJointAccelerations);
-    *             </pre>
+    *       <pre>
+    *                                                                                                                               InverseDynamicsCalculator calculator = new InverseDynamicsCalculator(input);
+    *                                                                                                                               calculator.setConsiderCoriolisAndCentrifugalForces(considerCoriolisAndCentrifugalForces);
+    *                                                                                                                               calculator.setConsiderJointAccelerations(considerJointAccelerations);
+    *                                                                                                                               </pre>
     */
    @Deprecated
    public InverseDynamicsCalculator(MultiBodySystemReadOnly input, boolean considerCoriolisAndCentrifugalForces, boolean considerJointAccelerations)
@@ -159,14 +166,16 @@ public class InverseDynamicsCalculator
     *                                             performance improvement.
     * @deprecated Use the following code snippet instead:
     *
-    *             <pre>
-    *             InverseDynamicsCalculator calculator = new InverseDynamicsCalculator(input, considerIgnoredSubtreesInertia);
-    *             calculator.setConsiderCoriolisAndCentrifugalForces(considerCoriolisAndCentrifugalForces);
-    *             calculator.setConsiderJointAccelerations(considerJointAccelerations);
-    *             </pre>
+    *       <pre>
+    *                                                                                                                               InverseDynamicsCalculator calculator = new InverseDynamicsCalculator(input, considerIgnoredSubtreesInertia);
+    *                                                                                                                               calculator.setConsiderCoriolisAndCentrifugalForces(considerCoriolisAndCentrifugalForces);
+    *                                                                                                                               calculator.setConsiderJointAccelerations(considerJointAccelerations);
+    *                                                                                                                               </pre>
     */
    @Deprecated
-   public InverseDynamicsCalculator(MultiBodySystemReadOnly input, boolean considerCoriolisAndCentrifugalForces, boolean considerJointAccelerations,
+   public InverseDynamicsCalculator(MultiBodySystemReadOnly input,
+                                    boolean considerCoriolisAndCentrifugalForces,
+                                    boolean considerJointAccelerations,
                                     boolean considerIgnoredSubtreesInertia)
    {
       this(input, considerIgnoredSubtreesInertia);
@@ -254,22 +263,7 @@ public class InverseDynamicsCalculator
 
    private void buildMultiBodyTree(RecursionStep parent, Collection<? extends JointReadOnly> jointsToIgnore)
    {
-      List<JointReadOnly> childrenJoints = new ArrayList<>(parent.rigidBody.getChildrenJoints());
-
-      if (childrenJoints.size() > 1)
-      { // Reorganize the joints in the children to ensure that loop closures are treated last.
-         List<JointReadOnly> loopClosureAncestors = new ArrayList<>();
-
-         for (int i = 0; i < childrenJoints.size();)
-         {
-            if (MultiBodySystemTools.doesSubtreeContainLoopClosure(childrenJoints.get(i).getSuccessor()))
-               loopClosureAncestors.add(childrenJoints.remove(i));
-            else
-               i++;
-         }
-
-         childrenJoints.addAll(loopClosureAncestors);
-      }
+      List<JointReadOnly> childrenJoints = MultiBodySystemTools.sortLoopClosureInChildrenJoints(parent.rigidBody);
 
       for (JointReadOnly childJoint : childrenJoints)
       {
@@ -332,10 +326,19 @@ public class InverseDynamicsCalculator
     * @param gravity the gravitational linear acceleration, it is usually equal to
     *                {@code (0, 0, -9.81)}.
     */
-   public void setGravitionalAcceleration(FrameTuple3DReadOnly gravity)
+   public void setGravitationalAcceleration(FrameTuple3DReadOnly gravity)
    {
       gravity.checkReferenceFrameMatch(input.getInertialFrame());
-      setGravitionalAcceleration((Tuple3DReadOnly) gravity);
+      setGravitationalAcceleration((Tuple3DReadOnly) gravity);
+   }
+
+   /**
+    * @deprecated Use {@link #setGravitationalAcceleration(FrameTuple3DReadOnly)} instead.
+    */
+   @Deprecated
+   public void setGravitionalAcceleration(FrameTuple3DReadOnly gravity)
+   {
+      setGravitationalAcceleration((Tuple3DReadOnly) gravity);
    }
 
    /**
@@ -348,11 +351,20 @@ public class InverseDynamicsCalculator
     * @param gravity the gravitational linear acceleration, it is usually equal to
     *                {@code (0, 0, -9.81)}.
     */
-   public void setGravitionalAcceleration(Tuple3DReadOnly gravity)
+   public void setGravitationalAcceleration(Tuple3DReadOnly gravity)
    {
       SpatialAcceleration rootAcceleration = initialRecursionStep.rigidBodyAcceleration;
       rootAcceleration.setToZero();
       rootAcceleration.getLinearPart().setAndNegate(gravity);
+   }
+
+   /**
+    * @deprecated Use {@link #setGravitationalAcceleration(Tuple3DReadOnly)} instead.
+    */
+   @Deprecated
+   public void setGravitionalAcceleration(Tuple3DReadOnly gravity)
+   {
+      setGravitationalAcceleration(gravity);
    }
 
    /**
@@ -365,9 +377,18 @@ public class InverseDynamicsCalculator
     * @param gravity the gravitational linear acceleration along the z-axis, it is usually equal to
     *                {@code -9.81}.
     */
+   public void setGravitationalAcceleration(double gravity)
+   {
+      setGravitationalAcceleration(0.0, 0.0, gravity);
+   }
+
+   /**
+    * @deprecated Use {@link #setGravitationalAcceleration(double)} instead.
+    */
+   @Deprecated
    public void setGravitionalAcceleration(double gravity)
    {
-      setGravitionalAcceleration(0.0, 0.0, gravity);
+      setGravitationalAcceleration(gravity);
    }
 
    /**
@@ -384,12 +405,21 @@ public class InverseDynamicsCalculator
     * @param gravityZ the gravitational linear acceleration along the z-axis, it is usually equal to
     *                 {@code -9.81}.
     */
-   public void setGravitionalAcceleration(double gravityX, double gravityY, double gravityZ)
+   public void setGravitationalAcceleration(double gravityX, double gravityY, double gravityZ)
    {
       SpatialAcceleration rootAcceleration = initialRecursionStep.rigidBodyAcceleration;
       rootAcceleration.setToZero();
       rootAcceleration.getLinearPart().set(gravityX, gravityY, gravityZ);
       rootAcceleration.negate();
+   }
+
+   /**
+    * @deprecated Use {@link #setGravitationalAcceleration(double, double, double)} instead.
+    */
+   @Deprecated
+   public void setGravitionalAcceleration(double gravityX, double gravityY, double gravityZ)
+   {
+      setGravitationalAcceleration(gravityX, gravityY, gravityZ);
    }
 
    /**
@@ -399,8 +429,8 @@ public class InverseDynamicsCalculator
     *
     * @param newRootAcceleration the new spatial acceleration of the root.
     * @throws ReferenceFrameMismatchException if any of the reference frames of
-    *                                         {@code newRootAcceleration} does not match this
-    *                                         calculator's root spatial acceleration's frames.
+    *       {@code newRootAcceleration} does not match this
+    *       calculator's root spatial acceleration's frames.
     */
    public void setRootAcceleration(SpatialAccelerationReadOnly newRootAcceleration)
    {
@@ -517,7 +547,7 @@ public class InverseDynamicsCalculator
     * not.
     *
     * @return {@code true} if this calculator is accounting for joint accelerations, {@code false}
-    *         otherwise.
+    *       otherwise.
     * @see #setConsiderJointAccelerations(boolean)
     */
    public boolean areJointAccelerationsConsidered()
@@ -530,7 +560,7 @@ public class InverseDynamicsCalculator
     * centrifugal effects or not.
     *
     * @return {@code true} if this calculator is accounting for Coriolis and centrifugal forces,
-    *         {@code false} otherwise.
+    *       {@code false} otherwise.
     * @see #setConsiderCoriolisAndCentrifugalForces(boolean)
     */
    public boolean areCoriolisAndCentrifugalForcesConsidered()
@@ -682,7 +712,9 @@ public class InverseDynamicsCalculator
       }
    }
 
-   /** Intermediate result used for garbage free operations. */
+   /**
+    * Intermediate result used for garbage free operations.
+    */
    private final SpatialForce jointForceFromChild = new SpatialForce();
 
    /**
@@ -814,9 +846,9 @@ public class InverseDynamicsCalculator
             {
                if (input.getJointsToIgnore().contains(childJoint))
                {
-                  SpatialInertia subtreeIneria = MultiBodySystemTools.computeSubtreeInertia(childJoint);
-                  subtreeIneria.changeFrame(getBodyFixedFrame());
-                  bodyInertia.add(subtreeIneria);
+                  SpatialInertia subtreeInertia = MultiBodySystemTools.computeSubtreeInertia(childJoint);
+                  subtreeInertia.changeFrame(getBodyFixedFrame());
+                  bodyInertia.add(subtreeInertia);
                }
             }
          }
@@ -1017,8 +1049,8 @@ public class InverseDynamicsCalculator
       {
          this.parent = parent;
          if (loopClosureJoint.getSuccessor() != successorRecursion.rigidBody)
-            throw new IllegalArgumentException("Rigid-body mismatch. Joint's successor: " + loopClosureJoint.getSuccessor() + ", recursion body: "
-                  + successorRecursion.rigidBody);
+            throw new IllegalArgumentException(
+                  "Rigid-body mismatch. Joint's successor: " + loopClosureJoint.getSuccessor() + ", recursion body: " + successorRecursion.rigidBody);
          if (loopClosureJoint == successorRecursion.joint)
             throw new IllegalArgumentException("This recursion joint should not be equal to the successor joint, joint: " + loopClosureJoint);
 

--- a/src/main/java/us/ihmc/mecano/algorithms/InverseDynamicsCalculator.java
+++ b/src/main/java/us/ihmc/mecano/algorithms/InverseDynamicsCalculator.java
@@ -40,39 +40,23 @@ public class InverseDynamicsCalculator
    private static final boolean DEFAULT_CONSIDER_ACCELERATIONS = true;
    private static final boolean DEFAULT_CONSIDER_CORIOLIS = true;
 
-   /**
-    * Defines the multi-body system to use with this calculator.
-    */
+   /** Defines the multi-body system to use with this calculator. */
    private final MultiBodySystemReadOnly input;
-   /**
-    * The root of the internal recursive algorithm.
-    */
+   /** The root of the internal recursive algorithm. */
    final RecursionStep initialRecursionStep;
-   /**
-    * Map to quickly retrieve information for each rigid-body.
-    */
+   /** Map to quickly retrieve information for each rigid-body. */
    final Map<RigidBodyReadOnly, RecursionStep> rigidBodyToRecursionStepMap = new LinkedHashMap<>();
-   /**
-    * Map to quickly retrieve information for each joint.
-    */
+   /** Map to quickly retrieve information for each joint. */
    private final Map<JointReadOnly, RecursionStepBasics> jointToRecursionStepMap = new LinkedHashMap<>();
 
-   /**
-    * The input of this algorithm: the acceleration matrix for all the joints to consider.
-    */
+   /** The input of this algorithm: the acceleration matrix for all the joints to consider. */
    private final DMatrixRMaj allJointAccelerationMatrix;
-   /**
-    * The output of this algorithm: the effort matrix for all the joints to consider.
-    */
+   /** The output of this algorithm: the effort matrix for all the joints to consider. */
    private final DMatrixRMaj allJointTauMatrix;
 
-   /**
-    * Whether the effort resulting from the joint accelerations should be considered.
-    */
+   /** Whether the effort resulting from the joint accelerations should be considered. */
    private boolean considerJointAccelerations = DEFAULT_CONSIDER_ACCELERATIONS;
-   /**
-    * Whether the effort resulting from the Coriolis and centrifugal forces should be considered.
-    */
+   /** Whether the effort resulting from the Coriolis and centrifugal forces should be considered. */
    private boolean considerCoriolisAndCentrifugalForces = DEFAULT_CONSIDER_CORIOLIS;
    /**
     * Extension of this algorithm into an acceleration provider that be used instead of a
@@ -97,10 +81,10 @@ public class InverseDynamicsCalculator
     * @deprecated Use the following code snippet instead:
     *
     *       <pre>
-    *                                                                                                                               InverseDynamicsCalculator calculator = new InverseDynamicsCalculator(rootBody);
-    *                                                                                                                               calculator.setConsiderCoriolisAndCentrifugalForces(considerCoriolisAndCentrifugalForces);
-    *                                                                                                                               calculator.setConsiderJointAccelerations(considerJointAccelerations);
-    *                                                                                                                               </pre>
+    *                                                                                                                                     InverseDynamicsCalculator calculator = new InverseDynamicsCalculator(rootBody);
+    *                                                                                                                                     calculator.setConsiderCoriolisAndCentrifugalForces(considerCoriolisAndCentrifugalForces);
+    *                                                                                                                                     calculator.setConsiderJointAccelerations(considerJointAccelerations);
+    *                                                                                                                                     </pre>
     */
    @Deprecated
    public InverseDynamicsCalculator(RigidBodyReadOnly rootBody, boolean considerCoriolisAndCentrifugalForces, boolean considerJointAccelerations)
@@ -127,10 +111,10 @@ public class InverseDynamicsCalculator
     * @deprecated Use the following code snippet instead:
     *
     *       <pre>
-    *                                                                                                                               InverseDynamicsCalculator calculator = new InverseDynamicsCalculator(input);
-    *                                                                                                                               calculator.setConsiderCoriolisAndCentrifugalForces(considerCoriolisAndCentrifugalForces);
-    *                                                                                                                               calculator.setConsiderJointAccelerations(considerJointAccelerations);
-    *                                                                                                                               </pre>
+    *                                                                                                                                     InverseDynamicsCalculator calculator = new InverseDynamicsCalculator(input);
+    *                                                                                                                                     calculator.setConsiderCoriolisAndCentrifugalForces(considerCoriolisAndCentrifugalForces);
+    *                                                                                                                                     calculator.setConsiderJointAccelerations(considerJointAccelerations);
+    *                                                                                                                                     </pre>
     */
    @Deprecated
    public InverseDynamicsCalculator(MultiBodySystemReadOnly input, boolean considerCoriolisAndCentrifugalForces, boolean considerJointAccelerations)
@@ -167,10 +151,10 @@ public class InverseDynamicsCalculator
     * @deprecated Use the following code snippet instead:
     *
     *       <pre>
-    *                                                                                                                               InverseDynamicsCalculator calculator = new InverseDynamicsCalculator(input, considerIgnoredSubtreesInertia);
-    *                                                                                                                               calculator.setConsiderCoriolisAndCentrifugalForces(considerCoriolisAndCentrifugalForces);
-    *                                                                                                                               calculator.setConsiderJointAccelerations(considerJointAccelerations);
-    *                                                                                                                               </pre>
+    *                                                                                                                                     InverseDynamicsCalculator calculator = new InverseDynamicsCalculator(input, considerIgnoredSubtreesInertia);
+    *                                                                                                                                     calculator.setConsiderCoriolisAndCentrifugalForces(considerCoriolisAndCentrifugalForces);
+    *                                                                                                                                     calculator.setConsiderJointAccelerations(considerJointAccelerations);
+    *                                                                                                                                     </pre>
     */
    @Deprecated
    public InverseDynamicsCalculator(MultiBodySystemReadOnly input,
@@ -712,9 +696,7 @@ public class InverseDynamicsCalculator
       }
    }
 
-   /**
-    * Intermediate result used for garbage free operations.
-    */
+   /** Intermediate result used for garbage free operations. */
    private final SpatialForce jointForceFromChild = new SpatialForce();
 
    /**

--- a/src/main/java/us/ihmc/mecano/algorithms/JointTorqueRegressorCalculator.java
+++ b/src/main/java/us/ihmc/mecano/algorithms/JointTorqueRegressorCalculator.java
@@ -304,9 +304,7 @@ public class JointTorqueRegressorCalculator
    {
       M, MCOM_X, MCOM_Y, MCOM_Z, I_XX, I_XY, I_XZ, I_YY, I_YZ, I_ZZ;
 
-      /**
-       * Utility method to get all the basis options, for use in loops.
-       */
+      /** Utility method to get all the basis options, for use in loops. */
       public static final SpatialInertiaBasisOption[] values = values();
 
       /**

--- a/src/main/java/us/ihmc/mecano/algorithms/MultiBodyGravityGradientCalculator.java
+++ b/src/main/java/us/ihmc/mecano/algorithms/MultiBodyGravityGradientCalculator.java
@@ -47,26 +47,18 @@ import java.util.*;
  */
 public class MultiBodyGravityGradientCalculator
 {
-   /**
-    * Defines the multi-body system to use with this calculator.
-    */
+   /** Defines the multi-body system to use with this calculator. */
    private final MultiBodySystemReadOnly input;
    /**
     * Output of this algorithm: joint efforts due to gravity and external wrenches for all the joint to
     * consider.
     */
    private final DMatrixRMaj tauMatrix;
-   /**
-    * Output of this algorithm: gradient of the {@link #tauMatrix}.
-    */
+   /** Output of this algorithm: gradient of the {@link #tauMatrix}. */
    private final DMatrixRMaj tauGradientMatrix;
-   /**
-    * The root of the internal recursive algorithm.
-    */
+   /** The root of the internal recursive algorithm. */
    private final AlgorithmStep initialStep;
-   /**
-    * Map to quickly retrieve information for each rigid-body.
-    */
+   /** Map to quickly retrieve information for each rigid-body. */
    private final Map<RigidBodyReadOnly, AlgorithmStep> rigidBodyToAlgorithmStepMap = new LinkedHashMap<>();
 
    /**
@@ -321,23 +313,15 @@ public class MultiBodyGravityGradientCalculator
       return tauGradientMatrix;
    }
 
-   /**
-    * Intermediate variable used to compute {@link AlgorithmStep#subTreeExternalSpatialForce}.
-    */
+   /** Intermediate variable used to compute {@link AlgorithmStep#subTreeExternalSpatialForce}. */
    private final SpatialForce childExternalSpatialForce = new SpatialForce();
-   /**
-    * Intermediate variable used to compute {@link AlgorithmStep#subTreeCoM}.
-    */
+   /** Intermediate variable used to compute {@link AlgorithmStep#subTreeCoM}. */
    private final FramePoint3D childCoM = new FramePoint3D();
 
-   /**
-    * This class represents a single step for this algorithm.
-    */
+   /** This class represents a single step for this algorithm. */
    private class AlgorithmStep
    {
-      /**
-       * The rigid-body for which this step is for.
-       */
+      /** The rigid-body for which this step is for. */
       private final RigidBodyReadOnly rigidBody;
       /**
        * Body inertia: usually equal to {@code rigidBody.getInertial()}. However, if at least one child of
@@ -345,17 +329,11 @@ public class MultiBodyGravityGradientCalculator
        * attached to the ignored joint.
        */
       private final SpatialInertia bodyInertia;
-      /**
-       * The corresponding matrix indices for each of this step's joint degree of freedom.
-       */
+      /** The corresponding matrix indices for each of this step's joint degree of freedom. */
       private final int[] jointIndices;
-      /**
-       * The algorithm step for the parent of this step's rigid-body.
-       */
+      /** The algorithm step for the parent of this step's rigid-body. */
       private final AlgorithmStep parent;
-      /**
-       * The algorithm steps for the children of this step's rigid-body.
-       */
+      /** The algorithm steps for the children of this step's rigid-body. */
       private final List<AlgorithmStep> children = new ArrayList<>();
 
       /**
@@ -378,17 +356,11 @@ public class MultiBodyGravityGradientCalculator
        */
       private boolean hasSubTreeExternalWrench = false;
 
-      /**
-       * The total mass of the subtree starting at this step.
-       */
+      /** The total mass of the subtree starting at this step. */
       private double subTreeMass;
-      /**
-       * The total center of mass of the subtree starting at this step.
-       */
+      /** The total center of mass of the subtree starting at this step. */
       private final FramePoint3D subTreeCoM = new FramePoint3D();
-      /**
-       * The sum of external wrenches applied to the subtree starting at this step.
-       */
+      /** The sum of external wrenches applied to the subtree starting at this step. */
       private final SpatialForce subTreeExternalSpatialForce = new SpatialForce();
       /**
        * The resulting force due to gravity on the subtree at the sutree's center of mass expressed in
@@ -512,9 +484,7 @@ public class MultiBodyGravityGradientCalculator
          subTreeCoM.scale(1.0 / subTreeMass);
       }
 
-      /**
-       * From leaves to root, compute the elements of the gradient matrix.
-       */
+      /** From leaves to root, compute the elements of the gradient matrix. */
       public void passTwo()
       {
          for (int i = 0; i < children.size(); i++)

--- a/src/main/java/us/ihmc/mecano/tools/MultiBodySystemTools.java
+++ b/src/main/java/us/ihmc/mecano/tools/MultiBodySystemTools.java
@@ -1,22 +1,17 @@
 package us.ihmc.mecano.tools;
 
+import org.ejml.data.DMatrix;
+import us.ihmc.mecano.frames.MovingReferenceFrame;
+import us.ihmc.mecano.multiBodySystem.interfaces.*;
+import us.ihmc.mecano.multiBodySystem.iterators.SubtreeStreams;
+import us.ihmc.mecano.spatial.SpatialInertia;
+
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import org.ejml.data.DMatrix;
-
-import us.ihmc.mecano.frames.MovingReferenceFrame;
-import us.ihmc.mecano.multiBodySystem.interfaces.JointBasics;
-import us.ihmc.mecano.multiBodySystem.interfaces.JointReadOnly;
-import us.ihmc.mecano.multiBodySystem.interfaces.OneDoFJointBasics;
-import us.ihmc.mecano.multiBodySystem.interfaces.RigidBodyBasics;
-import us.ihmc.mecano.multiBodySystem.interfaces.RigidBodyReadOnly;
-import us.ihmc.mecano.multiBodySystem.iterators.SubtreeStreams;
-import us.ihmc.mecano.spatial.SpatialInertia;
 
 /**
  * This class provides a variety of tools to facilitate operations that need to navigate through a
@@ -130,7 +125,7 @@ public class MultiBodySystemTools
     * @param start the rigid-body from where to begin the collection of joints.
     * @param end   the rigid-body where to stop the collection of joints.
     * @return the array of joints representing the path from {@code start} to {@code end}, or
-    *         {@code null} if the given rigid-bodies are not part of the same multi-body system.
+    *       {@code null} if the given rigid-bodies are not part of the same multi-body system.
     */
    public static JointBasics[] createJointPath(RigidBodyBasics start, RigidBodyBasics end)
    {
@@ -149,7 +144,7 @@ public class MultiBodySystemTools
     * @param start the rigid-body from where to begin the collection of joints.
     * @param end   the rigid-body where to stop the collection of joints.
     * @return the array of joints representing the path from {@code start} to {@code end}, or
-    *         {@code null} if the given rigid-bodies are not part of the same multi-body system.
+    *       {@code null} if the given rigid-bodies are not part of the same multi-body system.
     */
    public static JointReadOnly[] createJointPath(RigidBodyReadOnly start, RigidBodyReadOnly end)
    {
@@ -402,7 +397,7 @@ public class MultiBodySystemTools
     * @param ancestor            the query for the ancestor. A rigid-body is the ancestor of another
     *                            rigid-body if it is between the other rigid-body and the root body.
     * @return {@code true} if {@code candidateDescendant} is a descendant of {@code ancestor},
-    *         {@code false} otherwise.
+    *       {@code false} otherwise.
     */
    public static boolean isAncestor(RigidBodyReadOnly candidateDescendant, RigidBodyReadOnly ancestor)
    {
@@ -424,7 +419,7 @@ public class MultiBodySystemTools
     *
     * @param rigidBody the query.
     * @return the distance in number of joints between the {@code rigidBody} and the root body. This
-    *         method returns {@code 0} if the {@code rigidBody} is the root body.
+    *       method returns {@code 0} if the {@code rigidBody} is the root body.
     */
    public static int computeDistanceToRoot(RigidBodyReadOnly rigidBody)
    {
@@ -450,9 +445,9 @@ public class MultiBodySystemTools
     * @param descendant the descendant, often it is the end-effector.
     * @param ancestor   the ancestor of the descendant, often it is the root body.
     * @return the distance in number of joints between the {@code descendant} and the {@code ancestor}.
-    *         This method returns {@code 0} if the two rigid-bodies are the same. This method returns
-    *         {@code -1} if the given {@code ancestor} is not located between the {@code descendant}
-    *         and the root body.
+    *       This method returns {@code 0} if the two rigid-bodies are the same. This method returns
+    *       {@code -1} if the given {@code ancestor} is not located between the {@code descendant}
+    *       and the root body.
     */
    public static int computeDistanceToAncestor(RigidBodyReadOnly descendant, RigidBodyReadOnly ancestor)
    {
@@ -482,9 +477,9 @@ public class MultiBodySystemTools
     * @param firstBody  the first end of the kinematic chain to compute the distance of.
     * @param secondBody the second end of the kinematic chain to compute the distance of.
     * @return the distance in number of joints between the {@code firstBody} and the
-    *         {@code secondBody}. This method returns {@code 0} if the two rigid-bodies are the same.
+    *       {@code secondBody}. This method returns {@code 0} if the two rigid-bodies are the same.
     * @throws IllegalArgumentException if the two rigid-bodies do not belong to the same multi-body
-    *                                  system.
+    *       system.
     */
    public static int computeDistance(RigidBodyReadOnly firstBody, RigidBodyReadOnly secondBody)
    {
@@ -500,7 +495,7 @@ public class MultiBodySystemTools
     * @param secondBody the second end of the kinematic chain.
     * @return the number of degrees of freedom.
     * @throws IllegalArgumentException if the two rigid-bodies do not belong to the same multi-body
-    *                                  system.
+    *       system.
     */
    public static int computeDegreesOfFreedom(RigidBodyReadOnly firstBody, RigidBodyReadOnly secondBody)
    {
@@ -577,7 +572,7 @@ public class MultiBodySystemTools
     * @param secondBody the second rigid-body of the query.
     * @return the nearest common ancestor.
     * @throws IllegalArgumentException if the two rigid-bodies do not belong to the same multi-body
-    *                                  system.
+    *       system.
     */
    public static RigidBodyBasics computeNearestCommonAncestor(RigidBodyBasics firstBody, RigidBodyBasics secondBody)
    {
@@ -596,7 +591,7 @@ public class MultiBodySystemTools
     * @param secondBody the second rigid-body of the query.
     * @return the nearest common ancestor.
     * @throws IllegalArgumentException if the two rigid-bodies do not belong to the same multi-body
-    *                                  system.
+    *       system.
     */
    public static RigidBodyReadOnly computeNearestCommonAncestor(RigidBodyReadOnly firstBody, RigidBodyReadOnly secondBody)
    {
@@ -651,8 +646,9 @@ public class MultiBodySystemTools
       }
 
       // We are at the root and the ancestors still do not match => we are dealing with 2 distinct multi-body systems.
-      throw new IllegalArgumentException("The two rigid-bodies are not part of the same multi-body system: first root: " + firstAncestor.getName()
-            + ", second root: " + secondAncestor.getName());
+      throw new IllegalArgumentException(
+            "The two rigid-bodies are not part of the same multi-body system: first root: " + firstAncestor.getName() + ", second root: "
+            + secondAncestor.getName());
    }
 
    /**
@@ -1028,8 +1024,7 @@ public class MultiBodySystemTools
     */
    public static <T extends JointReadOnly> T[] filterJoints(JointReadOnly[] source, Class<T> clazz)
    {
-      @SuppressWarnings("unchecked")
-      T[] retArray = (T[]) Array.newInstance(clazz, computeNumberOfJointsOfType(clazz, source));
+      @SuppressWarnings("unchecked") T[] retArray = (T[]) Array.newInstance(clazz, computeNumberOfJointsOfType(clazz, source));
       filterJoints(source, retArray, clazz);
       return retArray;
    }
@@ -1067,12 +1062,12 @@ public class MultiBodySystemTools
    /**
     * Finds and returns the first joint contained in the subtree starting at the given rigid-body which
     * name matches the given name.
-    * 
+    *
     * @param start     where to start the search, if unsure, the root body should be given. Not
     *                  modified.
     * @param jointName the name of the joint to be found.
     * @return the joint matching the given name, or {@code null} if no joint with such name could be
-    *         found.
+    *       found.
     */
    public static JointReadOnly findJoint(RigidBodyReadOnly start, String jointName)
    {
@@ -1082,14 +1077,14 @@ public class MultiBodySystemTools
    /**
     * Finds and returns the first joint contained in the subtree starting at the given rigid-body which
     * name matches the given name.
-    * 
+    *
     * @param start      where to start the search, if unsure, the root body should be given. Not
     *                   modified.
     * @param jointName  the name of the joint to be found.
     * @param ignoreCase whether to ignore the case when comparing the name, see
     *                   {@link String#equalsIgnoreCase(String)}.
     * @return the joint matching the given name, or {@code null} if no joint with such name could be
-    *         found.
+    *       found.
     */
    public static JointReadOnly findJoint(RigidBodyReadOnly start, String jointName, boolean ignoreCase)
    {
@@ -1124,12 +1119,12 @@ public class MultiBodySystemTools
    /**
     * Finds and returns the first joint contained in the subtree starting at the given rigid-body which
     * name matches the given name.
-    * 
+    *
     * @param start     where to start the search, if unsure, the root body should be given. Not
     *                  modified.
     * @param jointName the name of the joint to be found.
     * @return the joint matching the given name, or {@code null} if no joint with such name could be
-    *         found.
+    *       found.
     */
    public static JointBasics findJoint(RigidBodyBasics start, String jointName)
    {
@@ -1139,14 +1134,14 @@ public class MultiBodySystemTools
    /**
     * Finds and returns the first joint contained in the subtree starting at the given rigid-body which
     * name matches the given name.
-    * 
+    *
     * @param start      where to start the search, if unsure, the root body should be given. Not
     *                   modified.
     * @param jointName  the name of the joint to be found.
     * @param ignoreCase whether to ignore the case when comparing the name, see
     *                   {@link String#equalsIgnoreCase(String)}.
     * @return the joint matching the given name, or {@code null} if no joint with such name could be
-    *         found.
+    *       found.
     */
    public static JointBasics findJoint(RigidBodyBasics start, String jointName, boolean ignoreCase)
    {
@@ -1156,12 +1151,12 @@ public class MultiBodySystemTools
    /**
     * Finds and returns the first rigid-body contained in the subtree (including {@code start})
     * starting at the given rigid-body which name matches the given name.
-    * 
+    *
     * @param start         where to start the search, if unsure, the root body should be given. Not
     *                      modified.
     * @param rigidBodyName the name of the rigid-body to be found.
     * @return the rigid-body matching the given name, or {@code null} if no rigid-body with such name
-    *         could be found.
+    *       could be found.
     */
    public static RigidBodyReadOnly findRigidBody(RigidBodyReadOnly start, String rigidBodyName)
    {
@@ -1171,14 +1166,14 @@ public class MultiBodySystemTools
    /**
     * Finds and returns the first rigid-body contained in the subtree (including {@code start})
     * starting at the given rigid-body which name matches the given name.
-    * 
+    *
     * @param start         where to start the search, if unsure, the root body should be given. Not
     *                      modified.
     * @param rigidBodyName the name of the rigid-body to be found.
     * @param ignoreCase    whether to ignore the case when comparing the name, see
     *                      {@link String#equalsIgnoreCase(String)}.
     * @return the rigid-body matching the given name, or {@code null} if no rigid-body with such name
-    *         could be found.
+    *       could be found.
     */
    public static RigidBodyReadOnly findRigidBody(RigidBodyReadOnly start, String rigidBodyName, boolean ignoreCase)
    {
@@ -1211,12 +1206,12 @@ public class MultiBodySystemTools
    /**
     * Finds and returns the first rigid-body contained in the subtree (including {@code start})
     * starting at the given rigid-body which name matches the given name.
-    * 
+    *
     * @param start         where to start the search, if unsure, the root body should be given. Not
     *                      modified.
     * @param rigidBodyName the name of the rigid-body to be found.
     * @return the rigid-body matching the given name, or {@code null} if no rigid-body with such name
-    *         could be found.
+    *       could be found.
     */
    public static RigidBodyBasics findRigidBody(RigidBodyBasics start, String rigidBodyName)
    {
@@ -1226,14 +1221,14 @@ public class MultiBodySystemTools
    /**
     * Finds and returns the first rigid-body contained in the subtree (including {@code start})
     * starting at the given rigid-body which name matches the given name.
-    * 
+    *
     * @param start         where to start the search, if unsure, the root body should be given. Not
     *                      modified.
     * @param rigidBodyName the name of the rigid-body to be found.
     * @param ignoreCase    whether to ignore the case when comparing the name, see
     *                      {@link String#equalsIgnoreCase(String)}.
     * @return the rigid-body matching the given name, or {@code null} if no rigid-body with such name
-    *         could be found.
+    *       could be found.
     */
    public static RigidBodyBasics findRigidBody(RigidBodyBasics start, String rigidBodyName, boolean ignoreCase)
    {
@@ -1259,7 +1254,7 @@ public class MultiBodySystemTools
     *
     * @param joints the query. Not modified.
     * @return {@code true} if the joints are stored in a continuous manner from root to leaf,
-    *         {@code false} otherwise.
+    *       {@code false} otherwise.
     */
    public static boolean areJointsInContinuousOrder(JointReadOnly[] joints)
    {
@@ -1291,7 +1286,7 @@ public class MultiBodySystemTools
     *
     * @param joints the query. Not modified.
     * @return {@code true} if the joints are stored in a continuous manner from root to leaf,
-    *         {@code false} otherwise.
+    *       {@code false} otherwise.
     */
    public static boolean areJointsInContinuousOrder(List<? extends JointReadOnly> joints)
    {
@@ -1307,10 +1302,10 @@ public class MultiBodySystemTools
    /**
     * Tests whether the subtree starting at the given rigid-body contains at least one loop closure or
     * not.
-    * 
+    *
     * @param start the rigid-body from which the subtree to test starts.
     * @return {@code true} if the subtree contains one or more loop closure, {@code false} if there is
-    *         no loop closure.
+    *       no loop closure.
     * @see JointReadOnly#isLoopClosure()
     */
    public static boolean doesSubtreeContainLoopClosure(RigidBodyReadOnly start)
@@ -1713,5 +1708,32 @@ public class MultiBodySystemTools
       }
 
       return startIndex;
+   }
+
+   /**
+    * Returns a list of the children joints of the given {@code rigidBody} sorted such that the joints that are part of a loop closure are treated last.
+    *
+    * @param rigidBody the query. Not modified.
+    * @return the list of children joints sorted such that the joints that are part of a loop closure are treated last.
+    */
+   public static List<JointReadOnly> sortLoopClosureInChildrenJoints(RigidBodyReadOnly rigidBody)
+   {
+      List<JointReadOnly> childrenJoints = new ArrayList<>(rigidBody.getChildrenJoints());
+
+      if (childrenJoints.size() > 1)
+      { // Reorganize the joints in the children to ensure that loop closures are treated last.
+         List<JointReadOnly> loopClosureAncestors = new ArrayList<>();
+
+         for (int i = 0; i < childrenJoints.size(); )
+         {
+            if (doesSubtreeContainLoopClosure(childrenJoints.get(i).getSuccessor()))
+               loopClosureAncestors.add(childrenJoints.remove(i));
+            else
+               i++;
+         }
+
+         childrenJoints.addAll(loopClosureAncestors);
+      }
+      return childrenJoints;
    }
 }

--- a/src/test/java/us/ihmc/mecano/algorithms/InverseDynamicsCalculatorTest.java
+++ b/src/test/java/us/ihmc/mecano/algorithms/InverseDynamicsCalculatorTest.java
@@ -1,12 +1,7 @@
 package us.ihmc.mecano.algorithms;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
-
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.log.LogTools;
 import us.ihmc.mecano.multiBodySystem.Joint;
@@ -15,6 +10,10 @@ import us.ihmc.mecano.multiBodySystem.RigidBody;
 import us.ihmc.mecano.multiBodySystem.SixDoFJoint;
 import us.ihmc.mecano.tools.JointStateType;
 import us.ihmc.mecano.tools.MultiBodySystemRandomTools;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
 
 @Disabled
 public class InverseDynamicsCalculatorTest
@@ -29,7 +28,7 @@ public class InverseDynamicsCalculatorTest
 
       List<OneDoFJoint> joints = MultiBodySystemRandomTools.nextOneDoFJointChain(random, 30);
       InverseDynamicsCalculator calculator = new InverseDynamicsCalculator(joints.get(0).getPredecessor());
-      calculator.setGravitionalAcceleration(-9.81);
+      calculator.setGravitationalAcceleration(-9.81);
 
       long totalTime = 0L;
 
@@ -65,7 +64,7 @@ public class InverseDynamicsCalculatorTest
       RigidBody floatingBody = MultiBodySystemRandomTools.nextRigidBody(random, "floatingBody", joints.get(0));
       joints.addAll(MultiBodySystemRandomTools.nextOneDoFJointChain(random, floatingBody, 30));
       InverseDynamicsCalculator calculator = new InverseDynamicsCalculator(elevator);
-      calculator.setGravitionalAcceleration(-9.81);
+      calculator.setGravitationalAcceleration(-9.81);
 
       long totalTime = 0L;
 
@@ -97,7 +96,7 @@ public class InverseDynamicsCalculatorTest
 
       List<OneDoFJoint> joints = MultiBodySystemRandomTools.nextOneDoFJointTree(random, 30);
       InverseDynamicsCalculator calculator = new InverseDynamicsCalculator(joints.get(0).getPredecessor());
-      calculator.setGravitionalAcceleration(-9.81);
+      calculator.setGravitationalAcceleration(-9.81);
 
       long totalTime = 0L;
 
@@ -133,7 +132,7 @@ public class InverseDynamicsCalculatorTest
       RigidBody floatingBody = MultiBodySystemRandomTools.nextRigidBody(random, "floatingBody", joints.get(0));
       joints.addAll(MultiBodySystemRandomTools.nextOneDoFJointTree(random, floatingBody, 30));
       InverseDynamicsCalculator calculator = new InverseDynamicsCalculator(elevator);
-      calculator.setGravitionalAcceleration(-9.81);
+      calculator.setGravitationalAcceleration(-9.81);
 
       long totalTime = 0L;
 

--- a/src/test/java/us/ihmc/mecano/algorithms/JointTorqueRegressorCalculatorTest.java
+++ b/src/test/java/us/ihmc/mecano/algorithms/JointTorqueRegressorCalculatorTest.java
@@ -43,7 +43,7 @@ public class JointTorqueRegressorCalculatorTest
 
       // Create an inverse dynamics calculator to compare torque results to
       InverseDynamicsCalculator inverseDynamicsCalculator = new InverseDynamicsCalculator(system);
-      inverseDynamicsCalculator.setGravitionalAcceleration(-9.81);
+      inverseDynamicsCalculator.setGravitationalAcceleration(-9.81);
       inverseDynamicsCalculator.compute();
       DMatrixRMaj expectedjointTau = inverseDynamicsCalculator.getJointTauMatrix();
 
@@ -110,7 +110,7 @@ public class JointTorqueRegressorCalculatorTest
 
             // Create an inverse dynamics calculator to compare torque results to
             InverseDynamicsCalculator inverseDynamicsCalculator = new InverseDynamicsCalculator(system);
-            inverseDynamicsCalculator.setGravitionalAcceleration(-9.81);
+            inverseDynamicsCalculator.setGravitationalAcceleration(-9.81);
             inverseDynamicsCalculator.compute();
             DMatrixRMaj expectedjointTau = inverseDynamicsCalculator.getJointTauMatrix();
 
@@ -189,7 +189,7 @@ public class JointTorqueRegressorCalculatorTest
 
             // Create an inverse dynamics calculator to compare torque results to
             InverseDynamicsCalculator inverseDynamicsCalculator = new InverseDynamicsCalculator(system);
-            inverseDynamicsCalculator.setGravitionalAcceleration(-9.81);
+            inverseDynamicsCalculator.setGravitationalAcceleration(-9.81);
             inverseDynamicsCalculator.compute();
             DMatrixRMaj expectedjointTau = inverseDynamicsCalculator.getJointTauMatrix();
 
@@ -267,7 +267,7 @@ public class JointTorqueRegressorCalculatorTest
 
             // Create an inverse dynamics calculator to compare torque results to
             InverseDynamicsCalculator inverseDynamicsCalculator = new InverseDynamicsCalculator(system);
-            inverseDynamicsCalculator.setGravitionalAcceleration(-9.81);
+            inverseDynamicsCalculator.setGravitationalAcceleration(-9.81);
             inverseDynamicsCalculator.compute();
             DMatrixRMaj expectedjointTau = inverseDynamicsCalculator.getJointTauMatrix();
 
@@ -346,7 +346,7 @@ public class JointTorqueRegressorCalculatorTest
 
             // Create an inverse dynamics calculator to compare torque results to
             InverseDynamicsCalculator inverseDynamicsCalculator = new InverseDynamicsCalculator(system);
-            inverseDynamicsCalculator.setGravitionalAcceleration(-9.81);
+            inverseDynamicsCalculator.setGravitationalAcceleration(-9.81);
             inverseDynamicsCalculator.compute();
             DMatrixRMaj expectedjointTau = inverseDynamicsCalculator.getJointTauMatrix();
 
@@ -424,7 +424,7 @@ public class JointTorqueRegressorCalculatorTest
 
             // Create an inverse dynamics calculator to compare torque results to
             InverseDynamicsCalculator inverseDynamicsCalculator = new InverseDynamicsCalculator(system);
-            inverseDynamicsCalculator.setGravitionalAcceleration(-9.81);
+            inverseDynamicsCalculator.setGravitationalAcceleration(-9.81);
             // Randomly pick rigid bodies to apply external wrenches to
             Map<RigidBodyReadOnly, Wrench> rigidBodiesToExternalWrenchMap = new LinkedHashMap<>();
             for (RigidBodyBasics body : system.getRootBody().subtreeArray())

--- a/src/test/java/us/ihmc/mecano/algorithms/MultiBodyGravityGradientCalculatorTest.java
+++ b/src/test/java/us/ihmc/mecano/algorithms/MultiBodyGravityGradientCalculatorTest.java
@@ -1,25 +1,19 @@
 package us.ihmc.mecano.algorithms;
 
+import org.ejml.data.DMatrixRMaj;
+import org.ejml.dense.row.CommonOps_DDRM;
+import org.junit.jupiter.api.Test;
+import us.ihmc.euclid.referenceFrame.ReferenceFrame;
+import us.ihmc.mecano.algorithms.TablePrinter.Alignment;
+import us.ihmc.mecano.multiBodySystem.interfaces.*;
+import us.ihmc.mecano.spatial.Wrench;
+import us.ihmc.mecano.tools.*;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.function.Function;
-
-import org.ejml.data.DMatrixRMaj;
-import org.ejml.dense.row.CommonOps_DDRM;
-import org.junit.jupiter.api.Test;
-
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
-import us.ihmc.mecano.algorithms.TablePrinter.Alignment;
-import us.ihmc.mecano.multiBodySystem.interfaces.*;
-import us.ihmc.mecano.spatial.Wrench;
-import us.ihmc.mecano.tools.JointStateType;
-import us.ihmc.mecano.tools.MecanoRandomTools;
-import us.ihmc.mecano.tools.MecanoTestTools;
-import us.ihmc.mecano.tools.MultiBodySystemRandomTools;
-import us.ihmc.mecano.tools.MultiBodySystemStateIntegrator;
-import us.ihmc.mecano.tools.MultiBodySystemTools;
 
 public class MultiBodyGravityGradientCalculatorTest
 {
@@ -41,7 +35,7 @@ public class MultiBodyGravityGradientCalculatorTest
          MultiBodySystemBasics input = MultiBodySystemBasics.toMultiBodySystemBasics(joints);
 
          InverseDynamicsCalculator inverseDynamics = new InverseDynamicsCalculator(input);
-         inverseDynamics.setGravitionalAcceleration(-GRAVITY);
+         inverseDynamics.setGravitationalAcceleration(-GRAVITY);
          inverseDynamics.setConsiderCoriolisAndCentrifugalForces(false);
          inverseDynamics.setConsiderJointAccelerations(false);
 
@@ -245,7 +239,7 @@ public class MultiBodyGravityGradientCalculatorTest
             RigidBodyBasics body = joints.get(jointIndex).getSuccessor();
             Wrench wrench = MecanoRandomTools.nextWrench(random, body.getBodyFixedFrame(), body.getBodyFixedFrame(), 10.0, 10.0);
             wrench.getLinearPart().setToZero();
-//            wrench.getAngularPart().setToZero();
+            //            wrench.getAngularPart().setToZero();
             wrenches.put(body, wrench);
          }
       }
@@ -540,16 +534,16 @@ public class MultiBodyGravityGradientCalculatorTest
       // Remember the wrenches in world, so we can re-apply them after integration.
       Map<RigidBodyBasics, Wrench> externalWrenchesWorld = new HashMap<>();
       externalWrenches.forEach((body, wrench) ->
-      {
-         Wrench wrenchInWorld = new Wrench(wrench);
-         wrenchInWorld.changeFrame(worldFrame);
-         externalWrenchesWorld.put(body, wrenchInWorld);
-      });
+                               {
+                                  Wrench wrenchInWorld = new Wrench(wrench);
+                                  wrenchInWorld.changeFrame(worldFrame);
+                                  externalWrenchesWorld.put(body, wrenchInWorld);
+                               });
 
       InverseDynamicsCalculator calculator = new InverseDynamicsCalculator(input);
       calculator.setConsiderCoriolisAndCentrifugalForces(false);
       calculator.setConsiderJointAccelerations(false);
-      calculator.setGravitionalAcceleration(-GRAVITY);
+      calculator.setGravitationalAcceleration(-GRAVITY);
       externalWrenches.forEach((body, wrench) -> calculator.getExternalWrench(body).set(wrench));
       calculator.compute();
       prevGravity.set(calculator.getJointTauMatrix());
@@ -610,16 +604,16 @@ public class MultiBodyGravityGradientCalculatorTest
       // Remember the wrenches in world, so we can re-apply them after integration.
       Map<RigidBodyBasics, Wrench> externalWrenchesWorld = new HashMap<>();
       externalWrenches.forEach((body, wrench) ->
-      {
-         Wrench wrenchInWorld = new Wrench(wrench);
-         wrenchInWorld.changeFrame(worldFrame);
-         externalWrenchesWorld.put(body, wrenchInWorld);
-      });
+                               {
+                                  Wrench wrenchInWorld = new Wrench(wrench);
+                                  wrenchInWorld.changeFrame(worldFrame);
+                                  externalWrenchesWorld.put(body, wrenchInWorld);
+                               });
 
       InverseDynamicsCalculator calculator = new InverseDynamicsCalculator(input);
       calculator.setConsiderCoriolisAndCentrifugalForces(false);
       calculator.setConsiderJointAccelerations(false);
-      calculator.setGravitionalAcceleration(-GRAVITY);
+      calculator.setGravitationalAcceleration(-GRAVITY);
       MultiBodySystemStateIntegrator integrator = new MultiBodySystemStateIntegrator(dq);
 
       int nDoFs = input.getNumberOfDoFs();

--- a/src/test/java/us/ihmc/mecano/algorithms/MultiBodyResponseCalculatorTest.java
+++ b/src/test/java/us/ihmc/mecano/algorithms/MultiBodyResponseCalculatorTest.java
@@ -1,22 +1,10 @@
 package us.ihmc.mecano.algorithms;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Random;
-import java.util.stream.Collectors;
-
 import org.ejml.data.DMatrixRMaj;
 import org.ejml.dense.row.CommonOps_DDRM;
 import org.ejml.dense.row.MatrixFeatures_DDRM;
 import org.ejml.dense.row.RandomMatrices_DDRM;
 import org.junit.jupiter.api.Test;
-
 import us.ihmc.euclid.referenceFrame.FrameVector3D;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.referenceFrame.tools.EuclidFrameRandomTools;
@@ -31,14 +19,7 @@ import us.ihmc.mecano.multiBodySystem.Joint;
 import us.ihmc.mecano.multiBodySystem.OneDoFJoint;
 import us.ihmc.mecano.multiBodySystem.PrismaticJoint;
 import us.ihmc.mecano.multiBodySystem.RevoluteJoint;
-import us.ihmc.mecano.multiBodySystem.interfaces.JointBasics;
-import us.ihmc.mecano.multiBodySystem.interfaces.JointMatrixIndexProvider;
-import us.ihmc.mecano.multiBodySystem.interfaces.JointReadOnly;
-import us.ihmc.mecano.multiBodySystem.interfaces.MultiBodySystemReadOnly;
-import us.ihmc.mecano.multiBodySystem.interfaces.OneDoFJointBasics;
-import us.ihmc.mecano.multiBodySystem.interfaces.OneDoFJointReadOnly;
-import us.ihmc.mecano.multiBodySystem.interfaces.RigidBodyBasics;
-import us.ihmc.mecano.multiBodySystem.interfaces.RigidBodyReadOnly;
+import us.ihmc.mecano.multiBodySystem.interfaces.*;
 import us.ihmc.mecano.spatial.SpatialAcceleration;
 import us.ihmc.mecano.spatial.SpatialImpulse;
 import us.ihmc.mecano.spatial.Twist;
@@ -47,12 +28,14 @@ import us.ihmc.mecano.spatial.interfaces.SpatialForceReadOnly;
 import us.ihmc.mecano.spatial.interfaces.SpatialVectorReadOnly;
 import us.ihmc.mecano.spatial.interfaces.TwistReadOnly;
 import us.ihmc.mecano.spatial.interfaces.WrenchReadOnly;
-import us.ihmc.mecano.tools.JointStateType;
-import us.ihmc.mecano.tools.MecanoRandomTools;
-import us.ihmc.mecano.tools.MecanoTestTools;
-import us.ihmc.mecano.tools.MultiBodySystemRandomTools;
+import us.ihmc.mecano.tools.*;
 import us.ihmc.mecano.tools.MultiBodySystemRandomTools.RandomFloatingRevoluteJointChain;
-import us.ihmc.mecano.tools.MultiBodySystemTools;
+
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MultiBodyResponseCalculatorTest
 {
@@ -320,8 +303,11 @@ public class MultiBodyResponseCalculatorTest
       assertApplySingleRigidBodyWrench(random, iteration, joints, Collections.emptyMap(), Collections.emptyList(), epsilon);
    }
 
-   private static void assertApplySingleRigidBodyWrench(Random random, int iteration, List<? extends JointBasics> joints,
-                                                        Map<RigidBodyReadOnly, WrenchReadOnly> externalWrenches, List<? extends JointReadOnly> jointsToIgnore,
+   private static void assertApplySingleRigidBodyWrench(Random random,
+                                                        int iteration,
+                                                        List<? extends JointBasics> joints,
+                                                        Map<RigidBodyReadOnly, WrenchReadOnly> externalWrenches,
+                                                        List<? extends JointReadOnly> jointsToIgnore,
                                                         double epsilon)
    {
       for (JointStateType state : JointStateType.values())
@@ -362,8 +348,11 @@ public class MultiBodyResponseCalculatorTest
       assertApplySingleRigidBodyImpulse(random, iteration, joints, Collections.emptyMap(), Collections.emptyList(), epsilon);
    }
 
-   private static void assertApplySingleRigidBodyImpulse(Random random, int iteration, List<? extends JointBasics> joints,
-                                                         Map<RigidBodyReadOnly, WrenchReadOnly> externalWrenches, List<? extends JointReadOnly> jointsToIgnore,
+   private static void assertApplySingleRigidBodyImpulse(Random random,
+                                                         int iteration,
+                                                         List<? extends JointBasics> joints,
+                                                         Map<RigidBodyReadOnly, WrenchReadOnly> externalWrenches,
+                                                         List<? extends JointReadOnly> jointsToIgnore,
                                                          double epsilon)
    {
       for (JointStateType state : JointStateType.values())
@@ -399,15 +388,22 @@ public class MultiBodyResponseCalculatorTest
                                           Math.max(1.0, CommonOps_DDRM.elementMaxAbs(qdd_expected)) * epsilon);
    }
 
-   private static void assertApplySingleRigidBodyImpulseViaIntegration(Random random, int iteration, List<? extends JointBasics> joints, double dt,
+   private static void assertApplySingleRigidBodyImpulseViaIntegration(Random random,
+                                                                       int iteration,
+                                                                       List<? extends JointBasics> joints,
+                                                                       double dt,
                                                                        double epsilon)
    {
       assertApplySingleRigidBodyImpulseViaIntegration(random, iteration, joints, dt, Collections.emptyMap(), Collections.emptyList(), epsilon);
    }
 
-   private static void assertApplySingleRigidBodyImpulseViaIntegration(Random random, int iteration, List<? extends JointBasics> joints, double dt,
+   private static void assertApplySingleRigidBodyImpulseViaIntegration(Random random,
+                                                                       int iteration,
+                                                                       List<? extends JointBasics> joints,
+                                                                       double dt,
                                                                        Map<RigidBodyReadOnly, WrenchReadOnly> externalWrenches,
-                                                                       List<? extends JointReadOnly> jointsToIgnore, double epsilon)
+                                                                       List<? extends JointReadOnly> jointsToIgnore,
+                                                                       double epsilon)
    {
       double gravity = EuclidCoreRandomTools.nextDouble(random, -10.0, -1.0);
 
@@ -447,7 +443,8 @@ public class MultiBodyResponseCalculatorTest
 
       TwistReadOnly targetTwistChangeActual = multiBodyResponseCalculator.getTwistChangeProvider().getTwistOfBody(target);
       Twist targetTwistOld = new Twist(target.getBodyFixedFrame().getTwistOfFrame());
-      Twist targetAccelerationIntegrated = new Twist(multiBodyResponseCalculator.getForwardDynamicsCalculator().getAccelerationProvider(false)
+      Twist targetAccelerationIntegrated = new Twist(multiBodyResponseCalculator.getForwardDynamicsCalculator()
+                                                                                .getAccelerationProvider(false)
                                                                                 .getRelativeAcceleration(rootBody, target));
       targetAccelerationIntegrated.scale(dt);
 
@@ -472,9 +469,12 @@ public class MultiBodyResponseCalculatorTest
       assertRigidBodyApparentInertiaInverse(random, iteration, joints, Collections.emptyMap(), Collections.emptyList(), epsilon);
    }
 
-   private static void assertRigidBodyApparentInertiaInverse(Random random, int iteration, List<? extends JointBasics> joints,
+   private static void assertRigidBodyApparentInertiaInverse(Random random,
+                                                             int iteration,
+                                                             List<? extends JointBasics> joints,
                                                              Map<RigidBodyReadOnly, WrenchReadOnly> externalWrenches,
-                                                             List<? extends JointReadOnly> jointsToIgnore, double epsilon)
+                                                             List<? extends JointReadOnly> jointsToIgnore,
+                                                             double epsilon)
    {
       for (JointStateType state : JointStateType.values())
          MultiBodySystemRandomTools.nextState(random, state, joints);
@@ -516,9 +516,12 @@ public class MultiBodyResponseCalculatorTest
       assertRigidBodyApparentLinearInertiaInverse(random, iteration, joints, Collections.emptyMap(), Collections.emptyList(), epsilon);
    }
 
-   private static void assertRigidBodyApparentLinearInertiaInverse(Random random, int iteration, List<? extends JointBasics> joints,
+   private static void assertRigidBodyApparentLinearInertiaInverse(Random random,
+                                                                   int iteration,
+                                                                   List<? extends JointBasics> joints,
                                                                    Map<RigidBodyReadOnly, WrenchReadOnly> externalWrenches,
-                                                                   List<? extends JointReadOnly> jointsToIgnore, double epsilon)
+                                                                   List<? extends JointReadOnly> jointsToIgnore,
+                                                                   double epsilon)
    {
       for (JointStateType state : JointStateType.values())
          MultiBodySystemRandomTools.nextState(random, state, joints);
@@ -549,8 +552,8 @@ public class MultiBodyResponseCalculatorTest
                                                                                                           .getAccelerationOfBody(target));
       expectedAccelerationChange.changeFrame(testWrenchFrame);
       EuclidFrameTestTools.assertEquals(expectedAccelerationChange.getLinearPart(),
-                                                    actualLinearAccelerationChange,
-                                                    Math.max(1.0, expectedAccelerationChange.getLinearPart().norm()) * epsilon);
+                                        actualLinearAccelerationChange,
+                                        Math.max(1.0, expectedAccelerationChange.getLinearPart().norm()) * epsilon);
    }
 
    private static void assertApplySingleJointWrench(Random random, int iteration, List<? extends JointBasics> joints, double epsilon)
@@ -558,8 +561,11 @@ public class MultiBodyResponseCalculatorTest
       assertApplySingleJointWrench(random, iteration, joints, Collections.emptyMap(), Collections.emptyList(), epsilon);
    }
 
-   private static void assertApplySingleJointWrench(Random random, int iteration, List<? extends JointBasics> joints,
-                                                    Map<RigidBodyReadOnly, WrenchReadOnly> externalWrenches, List<? extends JointReadOnly> jointsToIgnore,
+   private static void assertApplySingleJointWrench(Random random,
+                                                    int iteration,
+                                                    List<? extends JointBasics> joints,
+                                                    Map<RigidBodyReadOnly, WrenchReadOnly> externalWrenches,
+                                                    List<? extends JointReadOnly> jointsToIgnore,
                                                     double epsilon)
    {
       for (JointStateType state : JointStateType.values())
@@ -602,8 +608,11 @@ public class MultiBodyResponseCalculatorTest
       assertApplySingleJointImpulse(random, iteration, joints, Collections.emptyMap(), Collections.emptyList(), epsilon);
    }
 
-   private static void assertApplySingleJointImpulse(Random random, int iteration, List<? extends JointBasics> joints,
-                                                     Map<RigidBodyReadOnly, WrenchReadOnly> externalWrenches, List<? extends JointReadOnly> jointsToIgnore,
+   private static void assertApplySingleJointImpulse(Random random,
+                                                     int iteration,
+                                                     List<? extends JointBasics> joints,
+                                                     Map<RigidBodyReadOnly, WrenchReadOnly> externalWrenches,
+                                                     List<? extends JointReadOnly> jointsToIgnore,
                                                      double epsilon)
    {
       for (JointStateType state : JointStateType.values())
@@ -646,9 +655,13 @@ public class MultiBodyResponseCalculatorTest
       assertApplySingleJointImpulseViaIntegration(random, iteration, joints, dt, Collections.emptyMap(), Collections.emptyList(), epsilon);
    }
 
-   private static void assertApplySingleJointImpulseViaIntegration(Random random, int iteration, List<? extends JointBasics> joints, double dt,
+   private static void assertApplySingleJointImpulseViaIntegration(Random random,
+                                                                   int iteration,
+                                                                   List<? extends JointBasics> joints,
+                                                                   double dt,
                                                                    Map<RigidBodyReadOnly, WrenchReadOnly> externalWrenches,
-                                                                   List<? extends JointReadOnly> jointsToIgnore, double epsilon)
+                                                                   List<? extends JointReadOnly> jointsToIgnore,
+                                                                   double epsilon)
    {
       double gravity = EuclidCoreRandomTools.nextDouble(random, -10.0, -1.0);
 
@@ -692,8 +705,11 @@ public class MultiBodyResponseCalculatorTest
       assertJointApparentInertiaInverse(random, iteration, joints, Collections.emptyMap(), Collections.emptyList(), epsilon);
    }
 
-   private static void assertJointApparentInertiaInverse(Random random, int iteration, List<? extends JointBasics> joints,
-                                                         Map<RigidBodyReadOnly, WrenchReadOnly> externalWrenches, List<? extends JointReadOnly> jointsToIgnore,
+   private static void assertJointApparentInertiaInverse(Random random,
+                                                         int iteration,
+                                                         List<? extends JointBasics> joints,
+                                                         Map<RigidBodyReadOnly, WrenchReadOnly> externalWrenches,
+                                                         List<? extends JointReadOnly> jointsToIgnore,
                                                          double epsilon)
    {
       for (JointStateType state : JointStateType.values())
@@ -735,8 +751,11 @@ public class MultiBodyResponseCalculatorTest
       assertApplyMultipleWrenches(random, iteration, joints, Collections.emptyMap(), Collections.emptyList(), epsilon);
    }
 
-   private static void assertApplyMultipleWrenches(Random random, int iteration, List<? extends JointBasics> joints,
-                                                   Map<RigidBodyReadOnly, WrenchReadOnly> externalWrenches, List<? extends JointReadOnly> jointsToIgnore,
+   private static void assertApplyMultipleWrenches(Random random,
+                                                   int iteration,
+                                                   List<? extends JointBasics> joints,
+                                                   Map<RigidBodyReadOnly, WrenchReadOnly> externalWrenches,
+                                                   List<? extends JointReadOnly> jointsToIgnore,
                                                    double epsilon)
    {
       for (JointStateType state : JointStateType.values())
@@ -797,8 +816,11 @@ public class MultiBodyResponseCalculatorTest
       assertApplyMultipleImpulse(random, iteration, joints, Collections.emptyMap(), Collections.emptyList(), epsilon);
    }
 
-   private static void assertApplyMultipleImpulse(Random random, int iteration, List<? extends JointBasics> joints,
-                                                  Map<RigidBodyReadOnly, WrenchReadOnly> externalWrenches, List<? extends JointReadOnly> jointsToIgnore,
+   private static void assertApplyMultipleImpulse(Random random,
+                                                  int iteration,
+                                                  List<? extends JointBasics> joints,
+                                                  Map<RigidBodyReadOnly, WrenchReadOnly> externalWrenches,
+                                                  List<? extends JointReadOnly> jointsToIgnore,
                                                   double epsilon)
    {
       for (JointStateType state : JointStateType.values())
@@ -854,7 +876,10 @@ public class MultiBodyResponseCalculatorTest
                                           Math.max(1.0, CommonOps_DDRM.elementMaxAbs(qdd_expected)) * epsilon);
    }
 
-   private static void runAssertionViaTwistProvider(Random random, int iteration, List<? extends JointBasics> joints, double epsilon,
+   private static void runAssertionViaTwistProvider(Random random,
+                                                    int iteration,
+                                                    List<? extends JointBasics> joints,
+                                                    double epsilon,
                                                     ForwardDynamicsCalculator forwardDynamicsCalculator,
                                                     MultiBodyResponseCalculator multiBodyResponseCalculator)
    {
@@ -876,7 +901,10 @@ public class MultiBodyResponseCalculatorTest
       }
    }
 
-   private static void runAssertionsViaAccelerationProvider(Random random, int iteration, List<? extends JointBasics> joints, double epsilon,
+   private static void runAssertionsViaAccelerationProvider(Random random,
+                                                            int iteration,
+                                                            List<? extends JointBasics> joints,
+                                                            double epsilon,
                                                             ForwardDynamicsCalculator forwardDynamicsCalculator,
                                                             MultiBodyResponseCalculator multiBodyResponseCalculator)
    {
@@ -922,13 +950,14 @@ public class MultiBodyResponseCalculatorTest
       assertTrue(areEqual);
    }
 
-   private static ForwardDynamicsCalculator setupForwardDynamicsCalculator(MultiBodySystemReadOnly input, double gravity,
+   private static ForwardDynamicsCalculator setupForwardDynamicsCalculator(MultiBodySystemReadOnly input,
+                                                                           double gravity,
                                                                            Map<RigidBodyReadOnly, WrenchReadOnly> externalWrenches,
                                                                            Map<? extends RigidBodyReadOnly, ? extends SpatialForceReadOnly> testRigidBodyDisturbances,
                                                                            Map<? extends JointReadOnly, DMatrixRMaj> testJointDisturbances)
    {
       ForwardDynamicsCalculator calculator = new ForwardDynamicsCalculator(input);
-      calculator.setGravitionalAcceleration(gravity);
+      calculator.setGravitationalAcceleration(gravity);
       calculator.setExternalWrenchesToZero();
       externalWrenches.forEach(calculator::setExternalWrench);
       testRigidBodyDisturbances.forEach((body, disturbance) -> calculator.getExternalWrench(body).add(disturbance));
@@ -951,12 +980,13 @@ public class MultiBodyResponseCalculatorTest
       return calculator;
    }
 
-   private static MultiBodyResponseCalculator setupMultiBodyResponseCalculator(MultiBodySystemReadOnly input, double gravity,
+   private static MultiBodyResponseCalculator setupMultiBodyResponseCalculator(MultiBodySystemReadOnly input,
+                                                                               double gravity,
                                                                                Map<RigidBodyReadOnly, WrenchReadOnly> externalWrenches)
    {
       MultiBodyResponseCalculator multiBodyResponseCalculator = new MultiBodyResponseCalculator(input);
       ForwardDynamicsCalculator forwardDynamicsCalculator = multiBodyResponseCalculator.getForwardDynamicsCalculator();
-      forwardDynamicsCalculator.setGravitionalAcceleration(gravity);
+      forwardDynamicsCalculator.setGravitationalAcceleration(gravity);
 
       forwardDynamicsCalculator.setExternalWrenchesToZero();
       externalWrenches.forEach(forwardDynamicsCalculator::setExternalWrench);
@@ -964,8 +994,12 @@ public class MultiBodyResponseCalculatorTest
       return multiBodyResponseCalculator;
    }
 
-   private static void assertJointAccelerationMatrixEquals(MultiBodySystemReadOnly input, int iteration, DMatrixRMaj qdd_expected,
-                                                           DMatrixRMaj qdd_original, DMatrixRMaj qdd_change, double epsilon)
+   private static void assertJointAccelerationMatrixEquals(MultiBodySystemReadOnly input,
+                                                           int iteration,
+                                                           DMatrixRMaj qdd_expected,
+                                                           DMatrixRMaj qdd_original,
+                                                           DMatrixRMaj qdd_change,
+                                                           double epsilon)
    {
       DMatrixRMaj qdd_actual = new DMatrixRMaj(qdd_change.getNumRows(), 1);
       CommonOps_DDRM.add(qdd_original, qdd_change, qdd_actual);

--- a/src/test/java/us/ihmc/mecano/tools/MultiBodySystemStateIntegratorTest.java
+++ b/src/test/java/us/ihmc/mecano/tools/MultiBodySystemStateIntegratorTest.java
@@ -1,11 +1,6 @@
 package us.ihmc.mecano.tools;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.util.Random;
-
 import org.junit.jupiter.api.Test;
-
 import us.ihmc.euclid.geometry.Pose3D;
 import us.ihmc.euclid.geometry.interfaces.Pose3DBasics;
 import us.ihmc.euclid.matrix.Matrix3D;
@@ -30,6 +25,10 @@ import us.ihmc.mecano.spatial.SpatialVector;
 import us.ihmc.mecano.spatial.Twist;
 import us.ihmc.mecano.spatial.interfaces.FixedFrameSpatialAccelerationBasics;
 import us.ihmc.mecano.spatial.interfaces.FixedFrameTwistBasics;
+
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MultiBodySystemStateIntegratorTest
 {
@@ -184,10 +183,7 @@ public class MultiBodySystemStateIntegratorTest
             EuclidFrameTestTools.assertEquals(messagePrefix, angularVelocityFD, jointTwist.getAngularPart(), LARGE_EPSILON);
             EuclidFrameTestTools.assertEquals(messagePrefix, linearVelocityFD, jointTwist.getLinearPart(), LARGE_EPSILON);
 
-            EuclidFrameTestTools.assertEquals(messagePrefix,
-                                                          initialAcceleration.getAngularPart(),
-                                                          jointAcceleration.getAngularPart(),
-                                                          LARGE_EPSILON);
+            EuclidFrameTestTools.assertEquals(messagePrefix, initialAcceleration.getAngularPart(), jointAcceleration.getAngularPart(), LARGE_EPSILON);
             actualLinearAccelerationInWorld.setMatchingFrame(jointAcceleration.getLinearPart());
             EuclidFrameTestTools.assertEquals(messagePrefix, expectedLinearAccelerationInWorld, actualLinearAccelerationInWorld, EPSILON);
 
@@ -237,7 +233,7 @@ public class MultiBodySystemStateIntegratorTest
          double zd0 = expectedLinearVelocity.getZ();
 
          ForwardDynamicsCalculator calculator = new ForwardDynamicsCalculator(root);
-         calculator.setGravitionalAcceleration(gravity);
+         calculator.setGravitationalAcceleration(gravity);
 
          FrameVector3D actualLinearVelocity = new FrameVector3D();
          FrameVector3D actualLinearAcceleration = new FrameVector3D();
@@ -419,10 +415,7 @@ public class MultiBodySystemStateIntegratorTest
             EuclidFrameTestTools.assertEquals(messagePrefix, angularVelocityFD, jointTwist.getAngularPart(), LARGE_EPSILON);
             EuclidFrameTestTools.assertEquals(messagePrefix, linearVelocityFD, jointTwist.getLinearPart(), LARGE_EPSILON);
 
-            EuclidFrameTestTools.assertEquals(messagePrefix,
-                                                          initialAcceleration.getAngularPart(),
-                                                          jointAcceleration.getAngularPart(),
-                                                          LARGE_EPSILON);
+            EuclidFrameTestTools.assertEquals(messagePrefix, initialAcceleration.getAngularPart(), jointAcceleration.getAngularPart(), LARGE_EPSILON);
             actualLinearAccelerationInWorld.setMatchingFrame(jointAcceleration.getLinearPart());
             EuclidFrameTestTools.assertEquals(messagePrefix, expectedLinearAccelerationInWorld, actualLinearAccelerationInWorld, EPSILON);
 
@@ -472,7 +465,7 @@ public class MultiBodySystemStateIntegratorTest
          double zd0 = expectedLinearVelocity.getZ();
 
          ForwardDynamicsCalculator calculator = new ForwardDynamicsCalculator(root);
-         calculator.setGravitionalAcceleration(gravity);
+         calculator.setGravitationalAcceleration(gravity);
 
          FrameVector3D actualLinearVelocity = new FrameVector3D();
          FrameVector3D actualLinearAcceleration = new FrameVector3D();


### PR DESCRIPTION
This PR enables the `ForwardDynamicsCalculator` to compute the full joint wrench. The goal is to allow simulation to compute the wrenches across the robot body to do FEA and whatnot.