### PR TITLE
Fix/inertia naming

### DIFF
--- a/src/yovariables/java/us/ihmc/mecano/yoVariables/spatial/YoSpatialInertia.java
+++ b/src/yovariables/java/us/ihmc/mecano/yoVariables/spatial/YoSpatialInertia.java
@@ -82,8 +82,8 @@ public class YoSpatialInertia implements SpatialInertiaBasics, Settable<SpatialI
       this.expressedInFrame = expressedInFrame;
 
       mass = new YoDouble(bodyFrame.getName() + "_mass" + nameSuffix, registry);
-      centerOfMassOffset = new YoFrameVector3D(bodyFrame.getName() + "_centerOfMassOffset" + nameSuffix, expressedInFrame, registry);
-      momentOfInertia = new YoMatrix3D(bodyFrame.getName() + "_momentOfInertia", registry);
+      centerOfMassOffset = new YoFrameVector3D(bodyFrame.getName() + "_centerOfMassOffset", nameSuffix, expressedInFrame, registry);
+      momentOfInertia = new YoMatrix3D(bodyFrame.getName() + "_momentOfInertia", nameSuffix, registry);
    }
 
    /** {@inheritDoc} */


### PR DESCRIPTION
The names for `YoSpatialInertia` were being set incorrectly. Previously, the `nameSuffix` strings were being string-added on in the prefix argument. In this PR, they're refactored as inputs to the suffix argument.